### PR TITLE
Remove heat-all container

### DIFF
--- a/container-images/tcib/base/os/heat-base/heat-all/heat-all.yaml
+++ b/container-images/tcib/base/os/heat-base/heat-all/heat-all.yaml
@@ -1,8 +1,0 @@
-tcib_actions:
-- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-tcib_packages:
-  common:
-  - openstack-heat-api
-  - openstack-heat-engine
-  - openstack-heat-monolith
-tcib_user: heat

--- a/container-images/tripleo_containers.yaml
+++ b/container-images/tripleo_containers.yaml
@@ -67,8 +67,6 @@ container_images:
   image_source: tripleo
 - imagename: quay.io/tripleomastercentos9/openstack-haproxy:current-tripleo
   image_source: tripleo
-- imagename: quay.io/tripleomastercentos9/openstack-heat-all:current-tripleo
-  image_source: tripleo
 - imagename: quay.io/tripleomastercentos9/openstack-heat-api-cfn:current-tripleo
   image_source: tripleo
 - imagename: quay.io/tripleomastercentos9/openstack-heat-api:current-tripleo


### PR DESCRIPTION
This was used in standalone deployment process of TripleO.