### PR TITLE
Add a dev mode source file for local development

### DIFF
--- a/tcib-dev-env.rc
+++ b/tcib-dev-env.rc
@@ -1,0 +1,17 @@
+export TCIB_ANSIBLE_WORKPATH="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+export ANSIBLE_ROLES_PATH="${TCIB_ANSIBLE_WORKPATH}/roles"
+export TCIB_CONFIG_PATH="${TCIB_ANSIBLE_WORKPATH}/container-images"
+
+function unset-tcib-dev-env {
+  for i in $(env | grep ANSIBLE_ | awk -F'=' '{print $1}'); do
+    unset ${i}
+  done
+  for i in $(env | grep TCIB_ | awk -F'=' '{print $1}'); do
+    unset ${i}
+  done
+  echo -e "TCIB development environment deactivated.\n"
+  unset -f unset-tcib-dev-env
+}
+
+echo -e "TCIB development environment is now active"
+echo -e "Run 'unset-tcib-dev-env' to deactivate.\n"

--- a/tcib/client/container_image.py
+++ b/tcib/client/container_image.py
@@ -47,6 +47,7 @@ CONTAINER_IMAGES_BASE_PATH = os.path.join(
 if sys.prefix != "/usr" and not os.path.isdir(CONTAINER_IMAGES_BASE_PATH):
     CONTAINER_IMAGES_BASE_PATH = os.path.join(
         "/usr", "share", "tcib", "container-images")
+CONTAINER_IMAGES_BASE_PATH = os.environ.get("TCIB_CONFIG_PATH", CONTAINER_IMAGES_BASE_PATH)
 
 
 class Build(command.Command):


### PR DESCRIPTION
This copies the tripleo-ansible/ansible-test-env.rc approach of allowing image definition files to come from the local git checkout instead of an installed location.