### PR TITLE
Remove tcib rpm package

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -71,7 +71,6 @@ tcib_packages:
   - socat
   - sudo
   - tar
-  - tcib
   - util-linux-user
   - which
   modules:


### PR DESCRIPTION
Earlier openstack-tripleo-common-containers rpm package was used to provide container-images kolla files.
Since due to tripleo component depreaction,
this package will not longer exists.

It got replaced with tcib, which also does not
exists and it breaks the image build process.

While building image one can pass
```
--volume /usr/share/tcib/container-images:/usr/share/tcib/container-images:z
```
to fix the issue.