### PR TITLE
Install additional clients

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -6,5 +6,11 @@ tcib_packages:
   common:
   - python3-openstackclient
   - python3-osc-placement
+  - python3-barbicanclient
+  - python3-designateclient
+  - python3-heatclient
+  - pyhton3-ironicclient
+  - python3-manilaclient
+  - python3-octaviaclient
   - bash-completion
 tcib_user: cloud-admin


### PR DESCRIPTION
This ensures we install more client libraries so that we can use subcommands for all services supported by oko.

Note this change does not cover legacy clients because these do not work with clouds.yaml .