### PR TITLE
Update ci roles to work with build jobs

### DIFF
--- a/ci/roles/build_containers/defaults/main.yaml
+++ b/ci/roles/build_containers/defaults/main.yaml
@@ -68,3 +68,4 @@ openstack_release: master
 
 # Roles related vars
 tcib_repo: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
+

--- a/ci/roles/build_containers/templates/build_containers.sh.j2
+++ b/ci/roles/build_containers/templates/build_containers.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-openstack tripleo container image build \
+openstack tcib container image build \
 {%   if push_containers|bool %}
      --push \
 {%   endif %}
@@ -61,4 +61,5 @@ openstack tripleo container image build \
 {%   endif %}
      --tag {{ image_tag }} \
      --base {{ containers_base_image }} \
-     --prefix {{ container_name_prefix }} 
+     --prefix {{ container_name_prefix }}
+


### PR DESCRIPTION
The following changes were needed to get
container build jobs to pass:

 - use openstack tcib container build command
