### PR TITLE
Add path definition when building as root

### DIFF
--- a/ci/roles/build_containers/tasks/main.yaml
+++ b/ci/roles/build_containers/tasks/main.yaml
@@ -38,6 +38,8 @@
     chdir: "{{ work_dir }}"
   ansible.builtin.shell: |
     set -o pipefail && bash build_containers.sh 2>&1 {{ timestamper_cmd }} > {{ work_dir }}/logs/build.log
+  environment:
+   PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
 - name: Retrieve built images  # noqa risky-shell-pipe
   shell: "podman images | grep {{ container_name_prefix }} | awk '{ print $1 }'"


### PR DESCRIPTION
ci/roles/build_containers/tasks/main.yaml runs
the openstack tcib container build command
as root. The root user does not recognize
the installed openstack path.