### PR TITLE
Remove unused pacemaker packages

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -68,7 +68,6 @@ tcib_packages:
   - procps-ng
   - python3
   - rsync
-  - socat
   - sudo
   - tar
   - tcib

--- a/container-images/tcib/base/haproxy/haproxy.yaml
+++ b/container-images/tcib/base/haproxy/haproxy.yaml
@@ -3,8 +3,3 @@ tcib_actions:
 tcib_packages:
   common:
   - haproxy
-  - libqb
-  - pacemaker
-  - pacemaker-remote
-  - pcs
-  - resource-agents

--- a/container-images/tcib/base/mariadb/mariadb.yaml
+++ b/container-images/tcib/base/mariadb/mariadb.yaml
@@ -18,6 +18,5 @@ tcib_packages:
   - mariadb-server-galera
   - mariadb-server-utils
   - rsync
-  - socat
   - tar
 tcib_user: mysql

--- a/container-images/tcib/base/mariadb/mariadb.yaml
+++ b/container-images/tcib/base/mariadb/mariadb.yaml
@@ -6,7 +6,6 @@ tcib_actions:
 - run: cp /usr/share/tcib/container-images/kolla/mariadb/security_reset.expect{{ tcib_release is version('8', '==') | ternary('', '.10.5') }} /usr/local/bin/kolla_security_reset
 - run: chmod 755 /usr/local/bin/kolla_security_reset
 - run: rm -rf /var/lib/mysql/* /etc/my.cnf.d/mariadb-server.cnf /etc/my.cnf.d/auth_gssapi.cnf
-- run: mkdir -p /etc/libqb
 tcib_cmd: kolla_start
 tcib_entrypoint: dumb-init --
 tcib_packages:
@@ -14,16 +13,10 @@ tcib_packages:
   - expect
   - galera
   - hostname
-  - libqb
   - mariadb
   - mariadb-backup
   - mariadb-server-galera
   - mariadb-server-utils
-  - pacemaker
-  - pacemaker-remote
-  - pcs
-  - python3-pynacl
-  - resource-agents
   - rsync
   - socat
   - tar

--- a/container-images/tcib/base/os/cinder-base/cinder-backup/cinder-backup.yaml
+++ b/container-images/tcib/base/os/cinder-base/cinder-backup/cinder-backup.yaml
@@ -2,12 +2,5 @@ tcib_envs:
   MALLOC_ARENA_MAX: 1
   MALLOC_MMAP_THRESHOLD_: 131072
   MALLOC_TRIM_THRESHOLD_: 262144
-tcib_actions:
-- run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: mkdir -p /etc/libqb
-tcib_packages:
-  common:
-  - pacemaker
-  - pacemaker-remote
-  - pcs
+tcib_actions: []
 tcib_user: cinder

--- a/container-images/tcib/base/os/cinder-base/cinder-volume/cinder-volume.yaml
+++ b/container-images/tcib/base/os/cinder-base/cinder-volume/cinder-volume.yaml
@@ -6,11 +6,8 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: cp /usr/share/tcib/container-images/kolla/cinder-volume/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: cp /usr/share/tcib/container-images/kolla/cinder-volume/cinder-volume-sudoers /etc/sudoers.d/cinder-volume-sudoers
-- run: chmod 755 /usr/local/bin/kolla_extend_start && chmod 440 /etc/sudoers.d/cinder-volume-sudoers && mkdir -p /etc/libqb
+- run: chmod 755 /usr/local/bin/kolla_extend_start && chmod 440 /etc/sudoers.d/cinder-volume-sudoers
 tcib_packages:
   common:
-  - pacemaker
-  - pacemaker-remote
-  - pcs
   - python3-cinderlib
 tcib_user: cinder

--- a/container-images/tcib/base/os/manila-base/manila-share/manila-share.yaml
+++ b/container-images/tcib/base/os/manila-base/manila-share/manila-share.yaml
@@ -1,15 +1,9 @@
 tcib_actions:
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: mkdir -p /etc/libqb
 tcib_packages:
   common:
   - ceph-common
   - dbus-tools
-  - libqb
   - openstack-manila-share
-  - pacemaker
-  - pacemaker-remote
-  - pcs
-  - resource-agents
   - sqlite
 tcib_user: manila

--- a/container-images/tcib/base/ovn-base/ovn-northd/ovn-northd.yaml
+++ b/container-images/tcib/base/ovn-base/ovn-northd/ovn-northd.yaml
@@ -1,11 +1,5 @@
 tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: mkdir -p /etc/libqb
 tcib_packages:
   common:
-  - libqb
   - openvswitch-ovn-central
-  - pacemaker
-  - pacemaker-remote
-  - pcs
-  - resource-agents

--- a/container-images/tcib/base/rabbitmq/rabbitmq.yaml
+++ b/container-images/tcib/base/rabbitmq/rabbitmq.yaml
@@ -6,10 +6,5 @@ tcib_actions:
 tcib_packages:
   common:
   - hostname
-  - libqb
-  - pacemaker
-  - pacemaker-remote
-  - pcs
   - rabbitmq-server
-  - resource-agents
 tcib_user: rabbitmq

--- a/container-images/tcib/base/redis/redis.yaml
+++ b/container-images/tcib/base/redis/redis.yaml
@@ -1,15 +1,8 @@
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: mkdir /etc/libqb
 tcib_packages:
   common:
-  - libqb
-  - pacemaker
-  - pacemaker-remote
-  - pcs
   - procps-ng
   - redis
-  - resource-agents
-  - stunnel
 tcib_user: redis


### PR DESCRIPTION
We will not use pacemaker in oko deployment because operator should take care of clustering/HA.

Also socat is no longer used so this PR also removes it.