### PR TITLE
Fix typo on package install - openstackclient.yaml

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -9,7 +9,7 @@ tcib_packages:
   - python3-barbicanclient
   - python3-designateclient
   - python3-heatclient
-  - pyhton3-ironicclient
+  - python3-ironicclient
   - python3-manilaclient
   - python3-octaviaclient
   - bash-completion


### PR DESCRIPTION
python3-ironicclient is needed on this
container build.