### PR TITLE
Add python-tcib-containers package

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -70,7 +70,7 @@ tcib_packages:
   - rsync
   - sudo
   - tar
-  - tcib
+  - python-tcib-containers
   - util-linux-user
   - which
   modules:


### PR DESCRIPTION
python-tcib package is now available in podified component repo[1]. python-tcib-containers contains all the required container-images for tcib.

python-tcib-containers replaces the tcib package in this pr.

[1]. https://trunk.rdoproject.org/centos9-master/component/podified/current/