### PR TITLE
Add antelope excludes

### DIFF
--- a/ci/roles/build_containers/vars/main.yaml
+++ b/ci/roles/build_containers/vars/main.yaml
@@ -3,6 +3,9 @@ exclude_containers:
   master:
     centos9:
       - neutron-mlnx-agent
+  antelope:
+    centos9:
+      - neutron-mlnx-agent
   zed:
     centos9:
       - neutron-mlnx-agent


### PR DESCRIPTION
Antelope container builds are required
and vars need to be added.