### PR TITLE
Add exclude_containers option for osp18

### DIFF
--- a/ci/roles/build_containers/vars/main.yaml
+++ b/ci/roles/build_containers/vars/main.yaml
@@ -1,11 +1,11 @@
 ---
 exclude_containers:
   master:
-    centos9:
+    centos9: &exclude_cs9_master_containers
       - neutron-mlnx-agent
   antelope:
-    centos9:
-      - neutron-mlnx-agent
+    centos9: *exclude_cs9_master_containers
   zed:
-    centos9:
-      - neutron-mlnx-agent
+    centos9: *exclude_cs9_master_containers
+  osp18:
+    redhat9: *exclude_cs9_master_containers


### PR DESCRIPTION
This PR adds the osp18 exclude_containers
option and switches to use anchors to avoid
duplication.