### PR TITLE
Remove redundant exclude_containers

### DIFF
--- a/ci/roles/build_containers/vars/main.yaml
+++ b/ci/roles/build_containers/vars/main.yaml
@@ -1,11 +1,10 @@
 ---
 exclude_containers:
   master:
-    centos9: &exclude_cs9_master_containers
-      - neutron-mlnx-agent
+    centos9: []
   antelope:
-    centos9: *exclude_cs9_master_containers
+    centos9: []
   zed:
-    centos9: *exclude_cs9_master_containers
+    centos9: []
   osp18:
-    redhat9: *exclude_cs9_master_containers
+    redhat9: []


### PR DESCRIPTION
We have already removed neutorn-mlnx-agent so we don't need to exclude it.