### PR TITLE
tcib uses rhel as the distro for Red Hat distros

### DIFF
--- a/ci/roles/build_containers/vars/main.yaml
+++ b/ci/roles/build_containers/vars/main.yaml
@@ -7,4 +7,4 @@ exclude_containers:
   zed:
     centos9: []
   osp18:
-    redhat9: []
+    rhel9: []


### PR DESCRIPTION
Update the excludes list to keep to this
convention.