### PR TITLE
Remove cronie from base image

### DIFF
--- a/container-images/tcib/base/os/os.yaml
+++ b/container-images/tcib/base/os/os.yaml
@@ -2,7 +2,6 @@ tcib_actions:
 - run: dnf install -y {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 tcib_packages:
   common:
-  - cronie
   - iscsi-initiator-utils
   - python3-barbicanclient
   - python3-cinderclient


### PR DESCRIPTION
We'll implement all cron jobs using native CronJob resource so we no longer need to use cron inside containers.