### PR TITLE
Remove unused python3-ldappool

### DIFF
--- a/container-images/tcib/base/os/aodh-base/aodh-api/aodh-api.yaml
+++ b/container-images/tcib/base/os/aodh-base/aodh-api/aodh-api.yaml
@@ -6,5 +6,4 @@ tcib_packages:
   - httpd
   - mod_ssl
   - openstack-aodh-api
-  - python3-ldappool
   - python3-mod_wsgi

--- a/container-images/tcib/base/os/gnocchi-base/gnocchi-base.yaml
+++ b/container-images/tcib/base/os/gnocchi-base/gnocchi-base.yaml
@@ -10,5 +10,4 @@ tcib_packages:
   - librados2
   - mod_ssl
   - python3-boto3
-  - python3-ldappool
   - python3-mod_wsgi


### PR DESCRIPTION
Aodh and Gnocchi do not require this library, really.