### PR TITLE
Fix missing ss command in ironic-pxe container

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
@@ -11,3 +11,4 @@ tcib_packages:
   - dnsmasq
   - grub2-efi-x64
   - shim
+  - iproute


### PR DESCRIPTION
The ironic-pxe container requires ss command to check status of UDP port used by dnsmasq.