### PR TITLE
Rename openstack-release to use 'rhos'

### DIFF
--- a/ci/roles/build_containers/vars/main.yaml
+++ b/ci/roles/build_containers/vars/main.yaml
@@ -6,5 +6,5 @@ exclude_containers:
     centos9: []
   zed:
     centos9: []
-  osp18:
+  rhos18:
     rhel9: []


### PR DESCRIPTION
For downstream builds, the usual reference is
'rhos' rather than 'osp'.