### PR TITLE
Set label tcib_build_tag to match tag

### DIFF
--- a/ci/roles/build_containers/defaults/main.yaml
+++ b/ci/roles/build_containers/defaults/main.yaml
@@ -35,7 +35,7 @@ release: "{{ ansible_distribution_major_version }}"
 # Skip or not the build of the images
 # skip_build
 
-# image tag
+# Image tag suffix. The image label tcib_build_tag will also be set with this value.
 image_tag: ''
 
 # Image Prefix

--- a/tcib/builder/buildah.py
+++ b/tcib/builder/buildah.py
@@ -179,6 +179,7 @@ class BuildahBuilder(base.BaseBuilder):
         if self.debug:
             # TODO(bogdando): add --log-rusage for newer buildah
             bud_args.extend(['--loglevel=3'])
+        bud_args.extend(['--label', 'tcib_build_tag=%s' % self.tag])
         # TODO(aschultz): drop --format docker when oci format is properly
         # supported by the undercloud registry
         bud_args.extend(['--format', 'docker', '--tls-verify=False',

--- a/tcib/client/container_image.py
+++ b/tcib/client/container_image.py
@@ -191,7 +191,8 @@ class Build(command.Command):
             dest="tag",
             metavar="<image-tag>",
             default="current-podified",
-            help=_("Image tag (default: %(default)s)"),
+            help=_("Image tag suffix. The image label tcib_build_tag will "
+                   "also be set with this value. (default: %(default)s)"),
         )
         parser.add_argument(
             "--prefix",

--- a/tcib/tests/test_buildah.py
+++ b/tcib/tests/test_buildah.py
@@ -111,7 +111,8 @@ class TestBuildahBuilder(base.TestCase):
         container_build_path = WORK_DIR + '/' + 'fedora-base'
         logfile = '/tmp/kolla/fedora-base/fedora-base-build.log'
         buildah_cmd_build = ['--log-level=debug', 'bud', '--net=host',
-                             '--loglevel=3', '--format', 'docker',
+                             '--loglevel=3', '--label',
+                             'tcib_build_tag=latest', '--format', 'docker',
                              '--tls-verify=False', '--logfile',
                              logfile, '-t', dest, container_build_path]
         args.extend(buildah_cmd_build)
@@ -131,7 +132,8 @@ class TestBuildahBuilder(base.TestCase):
         dest = '127.0.0.1:8787/master/fedora-fedora-base:latest'
         container_build_path = WORK_DIR + '/' + 'fedora-base'
         logfile = '/tmp/kolla/fedora-base/fedora-base-build.log'
-        buildah_cmd_build = ['bud', '--net=host', '--format',
+        buildah_cmd_build = ['bud', '--net=host', '--label',
+                             'tcib_build_tag=latest', '--format',
                              'docker', '--tls-verify=False',
                              '--logfile', logfile, '-t', dest,
                              container_build_path]
@@ -155,6 +157,7 @@ class TestBuildahBuilder(base.TestCase):
         buildah_cmd_build = ['bud', '--net=host',
                              '--volume', '/etc/pki:/etc/pki',
                              '--volume', '/etc/dir2:/dir2',
+                             '--label', 'tcib_build_tag=latest',
                              '--format', 'docker',
                              '--tls-verify=False',
                              '--logfile', logfile, '-t', dest,


### PR DESCRIPTION
This will allow the original build tag to be discovered by inspecting a stable tag such as current-podified. This may become useful later to replace stable tags with versioned tags for minor updates of running services.