### PR TITLE
Updating tempest container

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
+Arx Cruz <arxcruz@redhat.com>
 Brendan Shephard <59072170+bshephar@users.noreply.github.com>
 Chandan Kumar <raukadah@gmail.com>
 Rabi Mishra <ramishra@redhat.com>

--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+HOMEDIR=/var/lib/tempest
+TEMPEST_DIR=$HOMEDIR/openshift
+
+pushd $HOMEDIR
+
+export OS_CLOUD=default
+
+TEMPEST_PATH=$HOMEDIR/
+if [ ! -z ${USE_EXTERNAL_FILES} ]; then
+    TEMPEST_PATH=$HOMEDIR/external_files/
+    mkdir -p $HOME/.config/openstack
+    cp ${TEMPEST_PATH}clouds.yaml $HOME/.config/openstack/clouds.yaml
+fi
+
+tempest init openshift
+
+pushd $TEMPEST_DIR
+
+discover-tempest-config --os-cloud $OS_CLOUD --debug --create identity.v3_endpoint_type public
+
+if [ ! -f ${TEMPEST_PATH}include.txt ]; then
+    echo "tempest.api.identity.v3" > ${TEMPEST_PATH}include.txt
+fi
+if [ ! -f ${TEMPEST_PATH}exclude.txt ]; then
+    touch ${TEMPEST_PATH}exclude.txt
+fi
+
+tempest run \
+    --include-list ${TEMPEST_PATH}include.txt \
+    --exclude-list ${TEMPEST_PATH}exclude.txt
+
+RETURN_VALUE=$?
+
+echo "Generate subunit"
+stestr last --subunit > ${TEMPEST_PATH}testrepository.subunit || true
+
+echo "Generate html result"
+subunit2html ${TEMPEST_PATH}testrepository.subunit ${TEMPEST_PATH}stestr_results.html || true
+
+echo Copying logs file
+cp -rf ${TEMPEST_DIR}/* ${TEMPEST_PATH}
+
+exit ${RETURN_VALUE}
+
+popd
+popd

--- a/container-images/tcib/base/os/tempest/tempest.yaml
+++ b/container-images/tcib/base/os/tempest/tempest.yaml
@@ -1,11 +1,22 @@
+tcib_envs:
+  USE_EXTERNAL_FILES: true
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/tempest_sudoers /etc/sudoers.d/tempest_sudoers
 - run: chmod 440 /etc/sudoers.d/tempest_sudoers
+- run: mkdir -p /var/lib/tempest/external_files
+- run: mkdir -p /var/lib/kolla/config_files
+- run: chown -R tempest.tempest /var/lib/tempest
+- run: touch /var/lib/kolla/config_files/config.json
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /var/lib/tempest/run_tempest.sh
+- run: chmod +x /var/lib/tempest/run_tempest.sh
+
+tcib_entrypoint: /var/lib/tempest/run_tempest.sh
 
 tcib_packages:
   common:
   - iputils
   - openstack-tempest-all
+
 tcib_user: tempest


### PR DESCRIPTION
Updating tempest container to run tempestconf and tempest, and export the results.
Initially, this container just install the required packages to run tempest, with this patch, it will also add the run_tempest.sh script to execute tempest automatically setting the tcib_entrypoint. This will make it easier to move forward with tempest running on edpm jobs.