### PR TITLE
Install python-tcib-containers package before it tries to

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -14,6 +14,7 @@ tcib_actions:
     crudini --set /etc/dnf/dnf.conf main plugins 1 &&
     crudini --set /etc/dnf/dnf.conf main skip_missing_names_on_install False &&
     crudini --set /etc/dnf/dnf.conf main tsflags nodocs
+- run: dnf install -y {{ tcib_packages['common'] | join(' ') }}
 - run: cp /usr/share/tcib/container-images/kolla/base/uid_gid_manage.sh /usr/local/bin/uid_gid_manage
 - run: chmod 755 /usr/local/bin/uid_gid_manage
 - run: bash /usr/local/bin/uid_gid_manage kolla hugetlbfs libvirt qemu
@@ -27,7 +28,6 @@ tcib_actions:
 - run: cp /usr/share/tcib/container-images/kolla/base/sudoers /etc/sudoers
 - run: chmod 440 /etc/sudoers
 - run: sed -ri '/^(passwd:|group:)/ s/systemd//g' /etc/nsswitch.conf
-- run: dnf install -y {{ tcib_packages['common'] | join(' ') }}
 - run: >-
     dnf -y reinstall which &&
     rpm -e --nodeps tzdata &&


### PR DESCRIPTION
install scripts to make it available to be build by other build systems like ocds/brew where a job cannot pre-install the package