### PR TITLE
Include qemu-img package with in openstackclient container

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -13,4 +13,5 @@ tcib_packages:
   - python3-manilaclient
   - python3-octaviaclient
   - bash-completion
+  - qemu-img
 tcib_user: cloud-admin


### PR DESCRIPTION
It is used in install_yamls validation script to convert the cirros image to raw format[1] while booting the instance on EDPM node.

Currently it is failing as qemu-img is not available in openstackclient container

[1]. https://github.com/openstack-k8s-operators/install_yamls/commit/d5179b43f5391a249105621294e0fe4f6ec5bee6#diff-974c268d83191dabcd8aff9f3a9cdb0619278615e5ddb49d5b9ad13094a49a6cR20