### PR TITLE
Require socat in mariadb image

### DIFF
--- a/container-images/tcib/base/mariadb/mariadb.yaml
+++ b/container-images/tcib/base/mariadb/mariadb.yaml
@@ -18,5 +18,6 @@ tcib_packages:
   - mariadb-server-galera
   - mariadb-server-utils
   - rsync
+  - socat
   - tar
 tcib_user: mysql


### PR DESCRIPTION
When galera is used with TLS, the SST method (rsync or mariabackup) requires encryption. This is currently achieved via a socat tunnel, so add socat as a dependency in the mariadb image.