### PR TITLE
Add tool to expose yum_update ansible tasks

### DIFF
--- a/roles/modify_container_image/tasks/yum_update_buildah.yml
+++ b/roles/modify_container_image/tasks/yum_update_buildah.yml
@@ -110,7 +110,7 @@
       command: >
         buildah run
           --volume {{ yum_update.path }}:/tmp/yum_update.sh:z
-          --volume {{ yum_repos_dir_path }}:/etc/yum.repos.d
+          --volume {{ yum_repos_dir_path }}:/etc/yum.repos.d{{ ':z' if yum_repos_dir_path != "/etc/yum.repos.d"}}
           {% if pkg_mgr_vars_stat.stat.exists %}
           --volume /etc/{{ pkg_mgr_suffix }}/vars:/etc/{{ pkg_mgr_suffix }}/vars
           {% endif %}

--- a/roles/modify_container_image/tasks/yum_update_buildah.yml
+++ b/roles/modify_container_image/tasks/yum_update_buildah.yml
@@ -1,4 +1,7 @@
 ---
+# NOTE(tonyb):
+# This by default creates an: application/vnd.oci.image.config.v1+json image
+# not a application/vnd.oci.image.manifest.v1+json.
 - import_tasks: precheck.yml
   tags:
     - always

--- a/roles/modify_container_image/templates/yum_update.sh.j2
+++ b/roles/modify_container_image/templates/yum_update.sh.j2
@@ -19,7 +19,7 @@ packages_for_update=
 if [ -n "$1" ] && [[ -n $REPOQUERY_CMD ]]; then
     installed_versions=$(rpm -qa --qf "%{NAME} = %{VERSION}-%{RELEASE}\n" | sort)
     # dnf repoquery return 1 when repo does not exists, but standalone does not
-    available_versions=$($REPOQUERY_CMD --quiet --provides --disablerepo='*' --enablerepo=$1 -a | sort || true)
+    available_versions=$($REPOQUERY_CMD --quiet --provides --disablerepo='*' --enablerepo=${1//,/ --enablerepo=} -a | sort || true)
     uptodate_versions=$(comm -12 <(printf "%s\n" "$installed_versions") <(printf "%s\n" "$available_versions"))
 
     installed=$(printf "%s\n" "$installed_versions" | cut -d= -f1 | sort)

--- a/roles/modify_container_image/templates/yum_update.sh.j2
+++ b/roles/modify_container_image/templates/yum_update.sh.j2
@@ -47,7 +47,7 @@ fi
 
 YUM_OPTS="{% if yum_cache is defined and yum_cache %}--setopt=keepcache=1{% endif %}"
 
-$PKG -y update $YUM_OPTS $packages_for_update
+$PKG -y update $YUM_OPTS --disablerepo='*' --enablerepo=${1//,/ --enablerepo=} $packages_for_update
 {% endif %}
 
 {% if yum_cache is defined and yum_cache %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ openstack.cli.extension =
 openstack.tcib.v1 =
     tcib_container_image_build = tcib.client.container_image:Build
     tcib_container_image_hotfix = tcib.client.container_image:HotFix
+    tcib_container_image_update = tcib.client.container_image:Update
 
 [tool:pytest]
 norecursedirs = .eggs .git .tox dist

--- a/tcib/client/container_image.py
+++ b/tcib/client/container_image.py
@@ -748,6 +748,7 @@ class HotFix(command.Command):
     """Hotfix container images with tcib."""
 
     log = logging.getLogger(__name__ + ".HotFix")
+    auth_required = False
 
     def get_parser(self, prog_name):
         parser = super(HotFix, self).get_parser(prog_name)

--- a/tcib/client/utils.py
+++ b/tcib/client/utils.py
@@ -266,6 +266,16 @@ def run_ansible_playbook(playbook, inventory, workdir, playbook_dir=None,
                     (timeout, playbook))
         return ('Running Ansible playbook: %s' % playbook)
 
+    def _is_venv():
+        return (hasattr(sys, 'real_prefix') or
+                (hasattr(sys, 'base_prefix') and
+                 sys.base_prefix != sys.prefix))
+
+    def _get_development_prefix():
+        src_file = getattr(sys.modules[__name__], "__file__", "")
+        # Remove 'tcib/client/utils.py' from the src_file
+        return src_file[:-20]
+
     if not playbook_dir:
         playbook_dir = workdir
 
@@ -387,6 +397,9 @@ def run_ansible_playbook(playbook, inventory, workdir, playbook_dir=None,
         '/usr/share/ceph-ansible/roles:'
         '/etc/ansible/roles'
     )
+    if _is_venv():
+        roles_path = os.path.join(_get_development_prefix(), 'roles')
+        env['ANSIBLE_ROLES_PATH'] += ":{}".format(roles_path)
     env['ANSIBLE_RETRY_FILES_ENABLED'] = False
     env['ANSIBLE_HOST_KEY_CHECKING'] = False
     env['ANSIBLE_TRANSPORT'] = connection


### PR DESCRIPTION
In some situtations it's desireable to update all RPMs in container that are from a specific repo.  This PR updates and exposes existing ansible tasks to do just that.