### PR TITLE
Install glanceclient

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -8,6 +8,7 @@ tcib_packages:
   - python3-osc-placement
   - python3-barbicanclient
   - python3-designateclient
+  - python3-glanceclient
   - python3-heatclient
   - python3-ironicclient
   - python3-manilaclient


### PR DESCRIPTION
This ensures we install glanceclient library so that we can use additional commands for glance service which are not supported/available in openstackclient.