### PR TITLE
Drop tcib_variables in favor of image_config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,14 @@
+Abhishek Kekane <akekane@redhat.com>
+Alan Bishop <abishop@redhat.com>
 Arx Cruz <arxcruz@redhat.com>
-Brendan Shephard <59072170+bshephar@users.noreply.github.com>
+Brendan Shephard <bshephar@redhat.com>
 Chandan Kumar <raukadah@gmail.com>
+Damien Ciabrini <dciabrin@redhat.com>
 Rabi Mishra <ramishra@redhat.com>
 Ronelle Landy <rlandy@redhat.com>
+Shreshtha Joshi <shrjoshi@redhat.com>
+Soniya Vyas <svyas@redhat.com>
 Steve Baker <sbaker@redhat.com>
 Takashi Kajinami <tkajinam@redhat.com>
+Tony Breeds <tony@bakeyournoodle.com>
+chandankumar <raukadah@gmail.com>


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/tcib/pull/56 allows source container-images from the build host, not an rpm.

The above patch adds a new variable tcib_variables[1] to store image_config dict update value[2] and move it out of loop[3].

The value stored in tcib_variables is not getting updated when it is used in loop leading to following error[4]
```
Error: cannot find Containerfile or Dockerfile in context directory"
```

This patch drops the tcib variables and moves the dict back to its place.

[1.] https://github.com/openstack-k8s-operators/tcib/pull/56/files#diff-11a2750a37ee46b0df221580918b8e61e0154531984bb2d0eb077c8f5b4a4834R571 [2.] https://github.com/openstack-k8s-operators/tcib/pull/56/files#diff-11a2750a37ee46b0df221580918b8e61e0154531984bb2d0eb077c8f5b4a4834L594 [3.] https://github.com/openstack-k8s-operators/tcib/pull/56/files#diff-11a2750a37ee46b0df221580918b8e61e0154531984bb2d0eb077c8f5b4a4834R591 [4.] https://bugs.launchpad.net/tripleo/+bug/2028329/comments/1