### PR TITLE
Ironic: remove unused ironic-inspector-client

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -13,7 +13,6 @@ tcib_packages:
   - parted
   - psmisc
   - python3-dracclient
-  - python3-ironic-inspector-client
   - python3-proliantutils
   - python3-pysnmp
   - python3-scciclient


### PR DESCRIPTION
Ironic no longer use this library and replaced it by openstacksdk[1].

[1] https://review.opendev.org/c/openstack/ironic/+/669855