### PR TITLE
Add option to parse a profile to tempestconf

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -2,6 +2,7 @@
 
 HOMEDIR=/var/lib/tempest
 TEMPEST_DIR=$HOMEDIR/openshift
+PROFILE_ARG=""
 
 pushd $HOMEDIR
 
@@ -14,11 +15,14 @@ if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     cp ${TEMPEST_PATH}clouds.yaml $HOME/.config/openstack/clouds.yaml
 fi
 
+if [-f ${TEMPEST_PATH}profile.yaml ]; then
+    PROFILE_ARG="--profile ${TEMPEST_PATH}profile.yaml"
+fi
 tempest init openshift
 
 pushd $TEMPEST_DIR
 
-discover-tempest-config --os-cloud $OS_CLOUD --debug --create identity.v3_endpoint_type public
+discover-tempest-config --os-cloud $OS_CLOUD --debug --create identity.v3_endpoint_type public ${PROFILE_ARG}
 
 if [ ! -f ${TEMPEST_PATH}include.txt ]; then
     echo "tempest.api.identity.v3" > ${TEMPEST_PATH}include.txt


### PR DESCRIPTION
Tempestconf allow user to pass a yaml file containing options to be overriden in tempest.conf file. This patch add this option, checking if the file profile.yaml exists, if so, it pass the --profile, otherwise, it maintain the default behavior.