### PR TITLE
Require stunnel in mariadb image

### DIFF
--- a/container-images/tcib/base/mariadb/mariadb.yaml
+++ b/container-images/tcib/base/mariadb/mariadb.yaml
@@ -19,5 +19,6 @@ tcib_packages:
   - mariadb-server-utils
   - rsync
   - socat
+  - stunnel
   - tar
 tcib_user: mysql


### PR DESCRIPTION
SST transfers can be encrypted with socat when the transfer method is mariabackup or rsync_tunnel. Starting mariadb 10.5, the later can be replaced by the rsync transfer method, which gain support for encrypted SST via stunnel.

Add stunnel in the mariadb image to be able to deprecate rsync_tunnel, which was implemented before rsync supported encryption.