### PR TITLE
Revert "Fix CVE-2022-38060"

### DIFF
--- a/container-images/kolla/base/set_configs.py
+++ b/container-images/kolla/base/set_configs.py
@@ -268,8 +268,21 @@ def validate_source(data):
 
 
 def load_config():
+    def load_from_env():
+        config_raw = os.environ.get("KOLLA_CONFIG")
+        if config_raw is None:
+            return None
+
+        # Attempt to read config
+        try:
+            return json.loads(config_raw)
+        except ValueError:
+            raise InvalidConfig('Invalid json for Kolla config')
+
     def load_from_file():
-        config_file = '/var/lib/kolla/config_files/config.json'
+        config_file = os.environ.get("KOLLA_CONFIG_FILE")
+        if not config_file:
+            config_file = '/var/lib/kolla/config_files/config.json'
         LOG.info("Loading config file at %s", config_file)
 
         # Attempt to read config file
@@ -283,7 +296,9 @@ def load_config():
                 raise InvalidConfig(
                     "Could not read file %s: %r" % (config_file, e))
 
-    config = load_from_file()
+    config = load_from_env()
+    if config is None:
+        config = load_from_file()
 
     LOG.info('Validating config file')
     validate_config(config)

--- a/container-images/kolla/base/sudoers
+++ b/container-images/kolla/base/sudoers
@@ -5,7 +5,6 @@
 
 # anyone in the kolla group may sudo -E (set the environment)
 Defaults: %kolla setenv
-Defaults secure_path="/var/lib/kolla/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # root may run any commands via sudo as the network seervice user.  This is
 # neededfor database migrations of existing services which have not been


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/tcib/pull/62 caused failures: 

https://logserver.rdoproject.org/20/39420/42/check/periodic-podified-edpm-deployment-antelope-ocp-crc-1cs9/2e359a3/ci-framework-data/logs/quay-io-openstack-k8s-operators-openstack-must-gather-sha256-44315d98038be6ade762a669a25e052c0fdd39d886d22900bfc1944a2eb0a9e3/namespaces/openstack/pods/ovsdbserver-nb-0/ovsdbserver-nb-0-describe.log

~~~
ERROR:__main__:Unexpected error:
Traceback (most recent call last):
  File "/usr/local/bin/kolla_set_configs", line 403, in main
    config = load_config()
  File "/usr/local/bin/kolla_set_configs", line 286, in load_config
    config = load_from_file()
  File "/usr/local/bin/kolla_set_configs", line 276, in load_from_file
    with open(config_file) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/kolla/config_files/config.json'
~~~

As we use different file: https://github.com/openstack-k8s-operators/ovn-operator/blob/main/pkg/ovndbcluster/const.go#L11, we are using different files across operators: https://github.com/search?q=org%3Aopenstack-k8s-operators%20KOLLA_CONFIG_FILE&type=code