### PR TITLE
creating tempest-extras container

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -78,4 +78,5 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-rsyslog:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-unbound:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified

--- a/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
@@ -1,0 +1,10 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: cd /usr/local; git clone https://opendev.org/openstack/whitebox-tempest-plugin
+- run: cd /usr/local/whitebox-tempest-plugin; pip install -e .
+
+tcib_packages:
+  common:
+  - python3-pip
+
+tcib_user: tempest


### PR DESCRIPTION
The container will include the tempest(or other) plugins
with has a public source, but does not shipped as rpm,
so from git repository.
