### PR TITLE
Remove oslo.vmware from nova/glance

### DIFF
--- a/container-images/tcib/base/os/glance-api/glance-api.yaml
+++ b/container-images/tcib/base/os/glance-api/glance-api.yaml
@@ -9,7 +9,6 @@ tcib_packages:
   - httpd
   - mod_ssl
   - openstack-glance
-  - python3-oslo-vmware
   - python3-rados
   - python3-rbd
   - qemu-img

--- a/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
+++ b/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
@@ -22,7 +22,6 @@ tcib_packages:
   - openvswitch
   - parted
   - python3-libguestfs
-  - python3-oslo-vmware
   - python3-rtslib
   - swtpm
   - swtpm-tools


### PR DESCRIPTION
The vmwareapi virt driver was deprecated a while ago[1] because of lack of CI and maintainers. Because we haven't seen any users attempting to use the driver even in TripleO project, let's remove the package to reduce image size.

[1] https://review.opendev.org/c/openstack/nova/+/863911