### PR TITLE
Revert "Revert "Fix CVE-2022-38060""

### DIFF
--- a/container-images/kolla/base/set_configs.py
+++ b/container-images/kolla/base/set_configs.py
@@ -268,21 +268,8 @@ def validate_source(data):
 
 
 def load_config():
-    def load_from_env():
-        config_raw = os.environ.get("KOLLA_CONFIG")
-        if config_raw is None:
-            return None
-
-        # Attempt to read config
-        try:
-            return json.loads(config_raw)
-        except ValueError:
-            raise InvalidConfig('Invalid json for Kolla config')
-
     def load_from_file():
-        config_file = os.environ.get("KOLLA_CONFIG_FILE")
-        if not config_file:
-            config_file = '/var/lib/kolla/config_files/config.json'
+        config_file = '/var/lib/kolla/config_files/config.json'
         LOG.info("Loading config file at %s", config_file)
 
         # Attempt to read config file
@@ -296,9 +283,7 @@ def load_config():
                 raise InvalidConfig(
                     "Could not read file %s: %r" % (config_file, e))
 
-    config = load_from_env()
-    if config is None:
-        config = load_from_file()
+    config = load_from_file()
 
     LOG.info('Validating config file')
     validate_config(config)

--- a/container-images/kolla/base/sudoers
+++ b/container-images/kolla/base/sudoers
@@ -5,6 +5,7 @@
 
 # anyone in the kolla group may sudo -E (set the environment)
 Defaults: %kolla setenv
+Defaults secure_path="/var/lib/kolla/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # root may run any commands via sudo as the network seervice user.  This is
 # neededfor database migrations of existing services which have not been


### PR DESCRIPTION
This reverts commit a741fcd4f1ac0ac1d9ad2ebef2636fa7cd8e4ed6.

Reason for revert:
The original change was reverted because of remaining usage of KOLLA_CONFIG_FILE but the environment is no longer used.