### PR TITLE
Gnocchi: Install apache in api container only

### DIFF
--- a/container-images/tcib/base/os/gnocchi-base/gnocchi-api/gnocchi-api.yaml
+++ b/container-images/tcib/base/os/gnocchi-base/gnocchi-api/gnocchi-api.yaml
@@ -4,3 +4,6 @@ tcib_actions:
 tcib_packages:
   common:
   - gnocchi-api
+  - httpd
+  - mod_ssl
+  - python3-mod_wsgi

--- a/container-images/tcib/base/os/gnocchi-base/gnocchi-base.yaml
+++ b/container-images/tcib/base/os/gnocchi-base/gnocchi-base.yaml
@@ -6,8 +6,5 @@ tcib_packages:
   - gnocchi-common
   - python3-rados
   - python3-eventlet
-  - httpd
   - librados2
-  - mod_ssl
   - python3-boto3
-  - python3-mod_wsgi


### PR DESCRIPTION
apache is required only by the api container and is not used by the other containers such as metricd.