### PR TITLE
Ceilometer: Remove unused oslo.db

### DIFF
--- a/container-images/tcib/base/os/ceilometer-base/ceilometer-base.yaml
+++ b/container-images/tcib/base/os/ceilometer-base/ceilometer-base.yaml
@@ -4,5 +4,3 @@ tcib_actions:
 tcib_packages:
   common:
   - openstack-ceilometer-common
-  - python3-oslo-db
-  - python3-tooz


### PR DESCRIPTION
Ceilometer no longer uses oslo.db, since it offloaded its metric storage and event storage.

Also explicit install of tooz library is not required because the package is part of dependencies and should be installed automatically.
