### PR TITLE
Ceilometer: Remove python3-pyngus

### DIFF
--- a/container-images/tcib/base/os/ceilometer-base/ceilometer-notification/ceilometer-notification.yaml
+++ b/container-images/tcib/base/os/ceilometer-base/ceilometer-notification/ceilometer-notification.yaml
@@ -3,5 +3,4 @@ tcib_actions:
 tcib_packages:
   common:
   - openstack-ceilometer-notification
-  - python3-pyngus
 tcib_user: ceilometer


### PR DESCRIPTION
This package was required to use amqp1 backend which is being deprecated[1].

Usage of amqp1 was required by current architecture of STF. However the architecture will be updated so that we no longer use qpid dispatch router(aka QDR). So this requirement will be no longer valid in operator deployment.

[1] https://review.opendev.org/c/openstack/oslo.messaging/+/861070