### PR TITLE
Minor fix on run_tempest.sh for tempest container

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -15,9 +15,10 @@ if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     cp ${TEMPEST_PATH}clouds.yaml $HOME/.config/openstack/clouds.yaml
 fi
 
-if [-f ${TEMPEST_PATH}profile.yaml ]; then
+if [ -f ${TEMPEST_PATH}profile.yaml ]; then
     PROFILE_ARG="--profile ${TEMPEST_PATH}profile.yaml"
 fi
+
 tempest init openshift
 
 pushd $TEMPEST_DIR


### PR DESCRIPTION
The profile.yaml test is missing a space, which is throwing an error and not setting the proper profile arguments.