### PR TITLE
Add concurrency support in tempest container

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -3,6 +3,7 @@
 HOMEDIR=/var/lib/tempest
 TEMPEST_DIR=$HOMEDIR/openshift
 PROFILE_ARG=""
+CONCURRENCY=""
 
 pushd $HOMEDIR
 
@@ -32,7 +33,11 @@ if [ ! -f ${TEMPEST_PATH}exclude.txt ]; then
     touch ${TEMPEST_PATH}exclude.txt
 fi
 
-tempest run \
+if [ -n ${CONCURRENCY} ]; then
+    CONCURRENCY="--concurrency ${CONCURRENCY}"
+fi
+
+tempest run ${CONCURRENCY} \
     --include-list ${TEMPEST_PATH}include.txt \
     --exclude-list ${TEMPEST_PATH}exclude.txt
 


### PR DESCRIPTION
At this moment, tempest is using all cpus available, and in some test cases this leads to timeout in some resources. Adding the hability to set the proper concurrency will fix this problems.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/526