### PR TITLE
Add Tobiko image

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -78,4 +78,5 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-unbound:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified

--- a/container-images/kolla/base/uid_gid_manage.sh
+++ b/container-images/kolla/base/uid_gid_manage.sh
@@ -69,6 +69,7 @@ _SUPPORTED_USERS['rabbitmq']='rabbitmq 42439 42439 /var/lib/rabbitmq kolla'
 _SUPPORTED_USERS['redis']='redis 42460 42460 /run/redis kolla'
 _SUPPORTED_USERS['swift']='swift 42445 42445 /var/lib/swift kolla'
 _SUPPORTED_USERS['tempest']='tempest 42480 42480 /var/lib/tempest kolla'
+_SUPPORTED_USERS['tobiko']='tobiko 42495 42495 /var/lib/tobiko kolla'
 _SUPPORTED_USERS['tss']='tss 59 59'
 
 for _USER_TO_CREATE in $_USERS_TO_CREATE; do

--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+TOBIKO_DIR=/var/lib/tobiko
+
+pushd ${TOBIKO_DIR}
+
+python3 -m tox -e py3 --notest
+source .tox/py3/bin/activate
+python3 -m stestr run -n tobiko/tobiko/tests/scenario/octavia/test_traffic.py
+
+RETURN_VALUE=$?
+
+echo Copying logs file
+# Take care of test results
+
+exit ${RETURN_VALUE}
+
+popd

--- a/container-images/tcib/base/os/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/os/tobiko/tobiko.yaml
@@ -3,13 +3,12 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/tobiko_sudoers /etc/sudoers.d/tobiko_sudoers
 - run: chmod 440 /etc/sudoers.d/tobiko_sudoers
-- run: cd /var/lib; git clone https://opendev.org/x/tobiko
+- run: git clone https://opendev.org/x/tobiko /opt/tobiko
   # The following line doesn't work
   #- run: cat {{ tobiko_config }} >> /var/lib/tobiko/tobiko.conf
 - run: python3 -m pip install --upgrade --user setuptools virtualenv wheel tox stestr
-- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
-- run: /var/lib/tobiko/tools/install-bindeps.sh
-- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
+- run: /opt/tobiko/tools/install-bindeps.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /opt/tobiko/run_tobiko.sh
 - run: chmod +x /var/lib/tobiko/run_tobiko.sh
 
 tcib_entrypoint: /var/lib/tobiko/run_tobiko.sh

--- a/container-images/tcib/base/os/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/os/tobiko/tobiko.yaml
@@ -1,0 +1,35 @@
+tcib_actions:
+- run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
+- run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/tobiko_sudoers /etc/sudoers.d/tobiko_sudoers
+- run: chmod 440 /etc/sudoers.d/tobiko_sudoers
+- run: cd /var/lib; git clone https://opendev.org/x/tobiko
+  # The following line doesn't work
+  #- run: cat {{ tobiko_config }} >> /var/lib/tobiko/tobiko.conf
+- run: python3 -m pip install --upgrade --user setuptools virtualenv wheel tox stestr
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
+- run: /var/lib/tobiko/tools/install-bindeps.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
+- run: chmod +x /var/lib/tobiko/run_tobiko.sh
+
+tcib_entrypoint: /var/lib/tobiko/run_tobiko.sh
+
+tcib_packages:
+  common:
+  - gcc
+  - git
+  - python3
+  - python3-devel
+  - python3-pip
+  - which
+  - findutils
+
+tcib_user: tobiko
+
+tobiko_config: |
+  [DEFAULT]
+  debug = true
+  log_file = tobiko.log
+
+  [ubuntu]
+  interface_name = enp3s0

--- a/container-images/tcib/base/os/tobiko/tobiko_sudoers
+++ b/container-images/tcib/base/os/tobiko/tobiko_sudoers
@@ -1,0 +1,1 @@
+tobiko        ALL=(ALL)       NOPASSWD: ALL


### PR DESCRIPTION
This patch adds the Tobiko container image. Tobiko can be found at https://opendev.org/x/tobiko, and it is an openstack system testing framework.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/543