### PR TITLE
Switch tcib to use the multinode layout

### DIFF
--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -20,8 +20,8 @@
       - OWNERS*
 
 - job:
-    name: tcib-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
+    name: tcib-podified-multinode-edpm-deployment-crc
+    parent: podified-multinode-edpm-deployment-crc
     irrelevant-files: *if
     vars: &edpm_vars
       cifmw_edpm_prepare_update_os_containers: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,4 +7,4 @@
         - tcib-crc-podified-edpm-baremetal: &content_provider
             dependencies:
               - tcib-build-containers
-        - tcib-crc-podified-edpm-deployment: *content_provider
+        - tcib-podified-multinode-edpm-deployment-crc: *content_provider


### PR DESCRIPTION
Since we are getting rid off the nested EDPM jobs we are now changing tcib to use the multinode based EDPM deployment job.