### PR TITLE
Add ceph-common to openstackclient to improve troubleshooting

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -7,6 +7,7 @@ tcib_actions:
 - run: rm /bin/sh && ln -s /bin/bash /bin/sh
 tcib_packages:
   common:
+  - ceph-common
   - python3-openstackclient
   - python3-osc-placement
   - python3-barbicanclient


### PR DESCRIPTION
Adding `ceph-common` package to the `openstackclient` means that if the `OpenStack` services are configured with `Ceph` but there are issues interacting with the cluster, we can use this Pod to ease any troubleshooting session instead of using container services (e.g. `cinder-api`) to find a working `rbd` client.
If an issue occurs (e.g. there are networking issues), mostly of the Pods that are trying to init the ceph driver will be in a `CrashLoopback`, hence even though the rbd client is present, we need to ask to `patch` an existing ctlplane CR just for testing purposes.
Finally, the `ceph-common` package is already available and provided by `RDO`, hence having it here doesn't hurt.