### PR TITLE
Fix run_tempest.sh

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+set -x
+
 HOMEDIR=/var/lib/tempest
 TEMPEST_DIR=$HOMEDIR/openshift
 PROFILE_ARG=""
-CONCURRENCY=""
+CONCURRENCY="${CONCURRENCY:-}"
 
 pushd $HOMEDIR
 
@@ -33,11 +35,11 @@ if [ ! -f ${TEMPEST_PATH}exclude.txt ]; then
     touch ${TEMPEST_PATH}exclude.txt
 fi
 
-if [ -n ${CONCURRENCY} ]; then
-    CONCURRENCY="--concurrency ${CONCURRENCY}"
+if [ -n "$CONCURRENCY" ]; then
+    CONCURRENCY_ARGS="--concurrency ${CONCURRENCY}"
 fi
 
-tempest run ${CONCURRENCY} \
+tempest run ${CONCURRENCY_ARGS:-} \
     --include-list ${TEMPEST_PATH}include.txt \
     --exclude-list ${TEMPEST_PATH}exclude.txt
 


### PR DESCRIPTION
The concurrency variable wasn't being set properly, as well as the check if the concurrency was set, making tempest jobs start to fail. This patch fixes it, and also set the shell to show the output of all commands, making it easier in the future to debug any failure.