### PR TITLE
Add neutron-ovn-agent container image

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -49,6 +49,7 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-neutron-sriov-agent:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-neutron-server:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-neutron-metadata-agent-ovn:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-neutron-ovn-agent:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-nova-api:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-nova-compute:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-nova-conductor:current-podified

--- a/container-images/tcib/base/os/neutron-base/neutron-agent-base/neutron-ovn-agent/neutron-ovn-agent.yaml
+++ b/container-images/tcib/base/os/neutron-base/neutron-agent-base/neutron-ovn-agent/neutron-ovn-agent.yaml
@@ -1,0 +1,6 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+tcib_packages:
+  common:
+  - openstack-neutron-ovn-agent
+tcib_user: neutron


### PR DESCRIPTION
The image will be used to setup neutron-ovn-agent on the EDPM nodes.

Related-Issue: [OSP-26191](https://issues.redhat.com//browse/OSP-26191)