### PR TITLE
qemu-img to tempest

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest.yaml
+++ b/container-images/tcib/base/os/tempest/tempest.yaml
@@ -20,5 +20,6 @@ tcib_packages:
   - openstack-tempest-all
   - subunit-filters
   - python3-subunit
+  - qemu-img
 
 tcib_user: tempest


### PR DESCRIPTION
discover-tempest-config/python-tempestconf wants to execute
qemu-img conver when --convert-to-raw argumant is passed.
