### PR TITLE
Skip build tobiko image

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -75,5 +75,6 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-unbound:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
-- imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
+# TODO(arxcruz/eolivare) Add tobiko back when we fix it
+# - imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified


### PR DESCRIPTION
Tobiko is failing to build right now in downstream, in order to unblock promotions, we are skipping it for now until we figure out the main reason.

CIX: [OSPCIX-100](https://issues.redhat.com//browse/OSPCIX-100)