### PR TITLE
Fix copy_rpms.yml

### DIFF
--- a/roles/modify_container_image/tasks/copy_rpms.yml
+++ b/roles/modify_container_image/tasks/copy_rpms.yml
@@ -9,7 +9,7 @@
 
 - name: Set rpms_list
   set_fact:
-    rpms_list: "{{  context_rpms.files|json_query('[*].path') }}"
+    rpms_list: "{{ context_rpms.files|map(attribute='path') }}"
   when: rpms_path is defined
 
 - name: Copy RPMs to context dir


### PR DESCRIPTION
The json_query filter raises 'Invalid plugin FQCN
(community.general.json_query): unable to locate
collection community.general'. Hence, we replace
json_query filter with map(attribute='path').