### PR TITLE
Revert "Skip build tobiko image"

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -75,6 +75,5 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-unbound:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
-# TODO(arxcruz/eolivare) Add tobiko back when we fix it
-# - imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified

--- a/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
@@ -2,6 +2,8 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: cd /usr/local; git clone https://opendev.org/openstack/whitebox-tempest-plugin
 - run: cd /usr/local/whitebox-tempest-plugin; pip install -e .
+- run: cd /usr/local; git clone https://github.com/openstack/tempest-stress
+- run: cd /usr/local/tempest-stress; pip install -e .
 
 tcib_packages:
   common:

--- a/roles/modify_container_image/tasks/copy_rpms.yml
+++ b/roles/modify_container_image/tasks/copy_rpms.yml
@@ -9,7 +9,7 @@
 
 - name: Set rpms_list
   set_fact:
-    rpms_list: "{{  context_rpms.files|json_query('[*].path') }}"
+    rpms_list: "{{ context_rpms.files|map(attribute='path') }}"
   when: rpms_path is defined
 
 - name: Copy RPMs to context dir


### PR DESCRIPTION
The downstream job should work fine after having updated the version of the tcib rpm.