### PR TITLE
Fix dependency handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ $ sudo dnf -y install ansible-core buildah
 
 3. Define subset of images to build
 
-By default all images will be built as specified
+By default all images and their dependencies will be built as specified
 in `container-images/containers.yaml` This can be limited to a subset of images
-with a custom containers file:
+and their depedencies with a custom containers file:
 
 ```
 $ cat containers.yaml
 container_images:
-  - imagename: quay.io/podified-master-centos9/openstack-base:current-podified
   - imagename: quay.io/podified-master-centos9/openstack-keystone:current-podified
 ```
 

--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -16,7 +16,6 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-cinder-volume:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-cron:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-designate-api:current-podified
-- imagename: quay.io/podified-master-centos9/openstack-designate-base:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-designate-backend-bind9:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-designate-central:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-designate-mdns:current-podified


### PR DESCRIPTION
The note[1] indicates that dependencies will be built but this
only appears to work for the first ancestor of an image.
Fix this by walking up the directory tree for a given image to
find all ancestors to include in the build.

Also record the level of each image and process in a breadth first order,
removing the hardcoded ordering for the 'base' and 'os' images.

[1] https://github.com/openstack-k8s-operators/tcib/blob/41a73ab686826c4fc2095cbe3f76b0dc2d61147f/tcib/client/container_image.py#L537-L541