### PR TITLE
Donot Install tcib from rpm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,22 @@
 Abhishek Kekane <akekane@redhat.com>
 Alan Bishop <abishop@redhat.com>
 Arx Cruz <arxcruz@redhat.com>
-Brendan Shephard <bshephar@redhat.com>
+Brendan Shephard <59072170+bshephar@users.noreply.github.com>
 Chandan Kumar <raukadah@gmail.com>
 Damien Ciabrini <dciabrin@redhat.com>
+Douglas Viroel <dviroel@redhat.com>
+Francesco Pantano <fpantano@redhat.com>
+Jaromír Wysoglad <jwysogla@redhat.com>
+OpenShift Merge Robot <openshift-merge-robot@users.noreply.github.com>
+Pablo Rodriguez Nava <pabrodri@redhat.com>
 Rabi Mishra <ramishra@redhat.com>
 Ronelle Landy <rlandy@redhat.com>
+Sandeep Yadav <sandyada@redhat.com>
+Sean Mooney <work@seanmooney.info>
 Shreshtha Joshi <shrjoshi@redhat.com>
 Soniya Vyas <svyas@redhat.com>
 Steve Baker <sbaker@redhat.com>
 Takashi Kajinami <tkajinam@redhat.com>
 Tony Breeds <tony@bakeyournoodle.com>
+afazekas <afazekas@redhat.com>
+rabi <ramishra@redhat.com>

--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -4,6 +4,7 @@
     parent: cifmw-tcib-base
     vars:
       cifmw_build_containers_registry_namespace: podified-antelope-centos9
+      cifmw_build_containers_install_from_source: true
     irrelevant-files: &if
       - HACKING.rst
       - AUTHORS
@@ -25,6 +26,7 @@
     irrelevant-files: *if
     vars: &edpm_vars
       cifmw_edpm_prepare_update_os_containers: true
+      cifmw_set_openstack_containers_edpm: true
       cifmw_set_openstack_containers_registry: "{{ content_provider_registry_ip }}:5001"
       cifmw_set_openstack_containers_tag_from_md5: true
       cifmw_set_openstack_containers_dlrn_md5_path: "~/ci-framework-data/artifacts/repositories/delorean.repo.md5"


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/ci-framework/pull/771 adds the support for installing tcib from rpm as a default behaviour. It also adds a var cifmw_build_containers_install_from_source to install it from source.

Since here tcib code is tested from source. So we need to update the zuul job definition so that tcib will get installed from source.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/799