### PR TITLE
Define tempest-all image

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -73,6 +73,7 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-rsyslog:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-unbound:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-tempest-all:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified

--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -17,7 +17,7 @@ tcib_entrypoint: /var/lib/tempest/run_tempest.sh
 tcib_packages:
   common:
   - iputils
-  - openstack-tempest
+  - openstack-tempest-all
   - subunit-filters
   - python3-subunit
   - qemu-img


### PR DESCRIPTION
Tempest image should contain only tempest while tempest-all image
should contain tempest with all relevant plugins.

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/97