### PR TITLE
Fix placement user creation

### DIFF
--- a/container-images/tcib/base/os/placement-api/placement-api.yaml
+++ b/container-images/tcib/base/os/placement-api/placement-api.yaml
@@ -1,4 +1,5 @@
 tcib_actions:
+- run: bash /usr/local/bin/uid_gid_manage placement
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf  && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
 tcib_packages:


### PR DESCRIPTION
Currently the placement user does not have a kolla generated uid and it is not in the kolla group:
```
❯ oc rsh placement-7ccc6bc7f5-cfchj
Defaulted container "placement-api" out of: placement-api, init (init)
sh-5.1# id
uid=0(root) gid=0(root) groups=0(root)
sh-5.1# cat /etc/passwd | grep placement
placement:x:997:994:OpenStack Placement:/:/bin/bash
sh-5.1# cat /etc/group | grep kolla
kolla:x:42400:
sh-5.1# 
```
This PR will make sure that during build the proper placemenet uid and group membership is used