### PR TITLE
Install observabilityclient

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -16,6 +16,7 @@ tcib_packages:
   - python3-heatclient
   - python3-ironicclient
   - python3-manilaclient
+  - python3-observabilityclient
   - python3-octaviaclient
   - bash-completion
   - iputils

--- a/container-images/tcib/base/os/os.yaml
+++ b/container-images/tcib/base/os/os.yaml
@@ -11,6 +11,7 @@ tcib_packages:
   - python3-manilaclient
   - python3-neutronclient
   - python3-novaclient
+  - python3-observabilityclient
   - python3-octaviaclient
   - python3-openstackclient
   - python3-swiftclient


### PR DESCRIPTION
This patch adds python3-observabilityclient dependency to OpenStack images. The package is new Aodh dependency.