### PR TITLE
Temporarly skip openstack-tempest-all

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -14,10 +14,12 @@ tcib_actions:
 
 tcib_entrypoint: /var/lib/tempest/run_tempest.sh
 
+# TODO(arxcruz): ADd openstack-tempest-all again once tempest-whitebox
+# package is available on rhel
 tcib_packages:
   common:
   - iputils
-  - openstack-tempest-all
+  - openstack-tempest
   - subunit-filters
   - python3-subunit
   - qemu-img


### PR DESCRIPTION
The package tempest-whitebox is not yet available on rhel, skipping it for now until we get a proper rpm being built.