### PR TITLE
[placement] remove example httpd /etc/httpd/conf.d/00-placement-api.conf

### DIFF
--- a/container-images/tcib/base/os/placement-api/placement-api.yaml
+++ b/container-images/tcib/base/os/placement-api/placement-api.yaml
@@ -2,6 +2,7 @@ tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage placement
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf  && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
+- run: rm -f /etc/httpd/conf.d/00-placement-api.conf
 tcib_packages:
   common:
   - httpd


### PR DESCRIPTION
The openstack-placement-api rpm provides an example placement httpd config at /etc/httpd/conf.d/00-placement-api.conf when enable httpd to read configs from /etc/httpd/conf.d to fail.

```
$ podman run -it -u root --rm quay.io/podified-antelope-centos9/openstack-placement-api:current-podified sh sh-5.1# rpm -qf /etc/httpd/conf.d/
00-placement-api.conf  autoindex.conf         README                 ssl.conf               userdir.conf           welcome.conf
sh-5.1# rpm -qf /etc/httpd/conf.d/00-placement-api.conf
openstack-placement-api-9.0.1-0.20230331173037.b3652fe.el9.noarch
```

This deletes this default config as the operator will provide a httpd config for placement.