### PR TITLE
Remove temporary skip of tempest-all package

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -14,12 +14,10 @@ tcib_actions:
 
 tcib_entrypoint: /var/lib/tempest/run_tempest.sh
 
-# TODO(arxcruz): ADd openstack-tempest-all again once tempest-whitebox
-# package is available on rhel
 tcib_packages:
   common:
   - iputils
-  - openstack-tempest
+  - openstack-tempest-all
   - subunit-filters
   - python3-subunit
   - qemu-img


### PR DESCRIPTION
openstack-tempest-all package was temporarily replaced with only
openstack-tempest one because whitebox-neutron-tempest plugin
wasn't available on rhel.
These patches make sure that the plugin is included in the
openstack-tempest-all package only in upstream:
https://review.rdoproject.org/r/q/I93f6cee77927dfadd15c8093b49b1ed1f3e04cdc
Thus it's safe to get the things back as they were.
