### PR TITLE
[tempest-extras]Add barbican tempest plugin

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
@@ -6,6 +6,8 @@ tcib_actions:
 - run: cd /usr/local/tempest-stress; pip install -e .
 - run: cd /usr/local; git clone https://opendev.org/openstack/manila-tempest-plugin.git
 - run: cd /usr/local/manila-tempest-plugin; pip install -e .
+- run: cd /usr/local; git clone https://opendev.org/openstack/barbican-tempest-plugin.git
+- run: cd /usr/local/barbican-tempest-plugin; pip install -e .
 
 tcib_packages:
   common:


### PR DESCRIPTION
The whitebox tempest plugin actually depends on the barbican tempest plugin otherwise the vTPM tests are failing with
```
    cls.os_primary.secrets_client = service_clients.secret_v1.SecretClient(
AttributeError: 'ServiceClients' object has no attribute 'secret_v1'
```
So this patch adding it.

Implements: https://issues.redhat.com/browse/OSPRH-2451