### PR TITLE
Adding some env variables to Tobiko image

### DIFF
--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -47,7 +47,7 @@ crudini --set tobiko.conf DEFAULT log_file ${TOBIKO_LOGFILE}
 [ ! -z ${TOBIKO_DEBUG} ] && crudini --set tobiko.conf DEFAULT debug true
 # testcase
 crudini --set tobiko.conf testcase timeout ${TOBIKO_TESTCASE_TIMEOUT}
-crudini --set tobiko.conf testcase timeout ${TOBIKO_TESTRUNNER_TIMEOUT}
+crudini --set tobiko.conf testcase test_runner_timeout ${TOBIKO_TESTRUNNER_TIMEOUT}
 # ubuntu
 crudini --set tobiko.conf ubuntu interface_name ${TOBIKO_UBUNTU_INTERFACE_NAME}
 [ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ] && crudini --set tobiko.conf ubuntu image_file ${TOBIKO_DIR}/.downloaded-images/ubuntu-minimal

--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -2,6 +2,9 @@
 
 TOBIKO_DIR=/var/lib/tobiko
 
+# assert mandatory variables have been set
+[ -z ${TOBIKO_TESTENV} ] && echo "TOBIKO_TESTENV not set" && exit 1
+
 # obtain clouds.yaml from external_files directory
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     mkdir -p $TOBIKO_DIR/.config/openstack
@@ -30,9 +33,7 @@ TOBIKO_TESTRUNNER_TIMEOUT="${TOBIKO_TESTRUNNER_TIMEOUT:-14400.0}"
 [ ! -z ${TOBIKO_PYTEST_ADDOPTS} ] && export PYTEST_ADDOPTS=${TOBIKO_PYTEST_ADDOPTS}
 [ ! -z ${TOBIKO_REPORT_DIR} ] && export TOX_REPORT_DIR=${TOBIKO_REPORT_DIR}
 [ ! -z ${TOBIKO_RUN_TESTS_TIMEOUT} ] && export TOX_RUN_TESTS_TIMEOUT=${TOBIKO_RUN_TESTS_TIMEOUT}
-
-# assert mandatory variables have been set
-[ -z ${TOBIKO_TESTENV} ] && echo "TOBIKO_TESTENV not set" && exit 1
+[ ! -z ${TOBIKO_PREVENT_CREATE} ] && export TOBIKO_PREVENT_CREATE=${TOBIKO_PREVENT_CREATE}
 
 pushd ${TOBIKO_DIR}
 git clone https://opendev.org/x/tobiko

--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -2,44 +2,68 @@
 
 TOBIKO_DIR=/var/lib/tobiko
 
+# obtain clouds.yaml from external_files directory
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     mkdir -p $TOBIKO_DIR/.config/openstack
     cp $TOBIKO_DIR/external_files/clouds.yaml $HOME/.config/openstack/
 fi
 
-pushd ${TOBIKO_DIR}
-
-export OS_CLOUD=default
-
+# download Ubuntu minimal image used by the Tobiko scenario tests, if needed
 if [ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ]; then
-    mkdir -p .downloaded-images
-    curl ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} -o .downloaded-images/ubuntu-minimal
+    mkdir -p ${TOBIKO_DIR}/.downloaded-images
+    curl ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} -o ${TOBIKO_DIR}/.downloaded-images/ubuntu-minimal
 fi
 
+
+# set default values for the required variables
+TOBIKO_VERSION=${TOBIKO_VERSION:-master}
+TOBIKO_UBUNTU_INTERFACE_NAME=${TOBIKO_UBUNTU_INTERFACE_NAME:-enp3s0}
+TOBIKO_KEYSTONE_INTERFACE=${TOBIKO_KEYSTONE_INTERFACE:-public}
+TOBIKO_LOGFILE=${TOBIKO_LOGFILE:-tobiko.log}
+TOBIKO_TESTCASE_TIMEOUT="${TOBIKO_TESTCASE_TIMEOUT:-1800.0}"
+TOBIKO_TESTRUNNER_TIMEOUT="${TOBIKO_TESTRUNNER_TIMEOUT:-14400.0}"
+
+# export OS_CLOUD variable
+[ ! -z ${TOBIKO_OS_CLOUD} ] && export OS_CLOUD=${TOBIKO_OS_CLOUD} || export OS_CLOUD=default
+
+# export optional variables, relevant for tox and pytest execution (see tobiko tox.ini file)
+[ ! -z ${TOBIKO_PYTEST_ADDOPTS} ] && export PYTEST_ADDOPTS=${TOBIKO_PYTEST_ADDOPTS}
+[ ! -z ${TOBIKO_REPORT_DIR} ] && export TOX_REPORT_DIR=${TOBIKO_REPORT_DIR}
+[ ! -z ${TOBIKO_RUN_TESTS_TIMEOUT} ] && export TOX_RUN_TESTS_TIMEOUT=${TOBIKO_RUN_TESTS_TIMEOUT}
+
+# assert mandatory variables have been set
+[ -z ${TOBIKO_TESTENV} ] && echo "TOBIKO_TESTENV not set" && exit 1
+
+pushd ${TOBIKO_DIR}
 git clone https://opendev.org/x/tobiko
-
 pushd tobiko
-echo '
-[DEFAULT]
-debug = true
-log_file = tobiko.log
+git checkout ${TOBIKO_VERSION}
 
-[ubuntu]
-interface_name = enp3s0
-image_file = /var/lib/tobiko/.downloaded-images/ubuntu-minimal
+# generate tobiko.conf
+# DEFAULT
+crudini --set tobiko.conf DEFAULT log_file ${TOBIKO_LOGFILE}
+[ ! -z ${TOBIKO_REPORT_DIR} ] && crudini --set tobiko.conf DEFAULT log_dir ${TOBIKO_REPORT_DIR}
+[ ! -z ${TOBIKO_DEBUG} ] && crudini --set tobiko.conf DEFAULT debug true
+# testcase
+crudini --set tobiko.conf testcase timeout ${TOBIKO_TESTCASE_TIMEOUT}
+crudini --set tobiko.conf testcase timeout ${TOBIKO_TESTRUNNER_TIMEOUT}
+# ubuntu
+crudini --set tobiko.conf ubuntu interface_name ${TOBIKO_UBUNTU_INTERFACE_NAME}
+[ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ] && crudini --set tobiko.conf ubuntu image_file ${TOBIKO_DIR}/.downloaded-images/ubuntu-minimal
+# keystone
+crudini --set tobiko.conf keystone interface ${TOBIKO_KEYSTONE_INTERFACE}
+[ ! -z ${TOBIKO_MANILA_SHARE_PROTOCOL} ] && crudini --set tobiko.conf manila share_protocol ${TOBIKO_MANILA_SHARE_PROTOCOL}
 
-[keystone]
-interface = public' > tobiko.conf
-
-if [ ! -z ${TOBIKO_VERSION} ]; then
-    git checkout ${TOBIKO_VERSION}
-fi
-python3 -m tox -e py3 --notest
-python3 -m tox -e scenario
+# run tobiko tests
+python3 -m tox -e ${TOBIKO_TESTENV}
 RETURN_VALUE=$?
 
-echo "Copying logs file"
-cp -rf /var/lib/tobiko/tobiko/.tox/py3/log $TOBIKO_DIR
-
+# copy logs to external_files
+if [ ! -z ${USE_EXTERNAL_FILES} ]; then
+    echo "Copying logs file"
+    LOG_DIR=${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/py3/log}
+    cp -rf ${LOG_DIR} ${TOBIKO_DIR}/external_files/
+    cp tobiko.conf ${TOBIKO_DIR}/external_files/
+fi
 
 exit ${RETURN_VALUE}

--- a/container-images/tcib/base/os/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/os/tobiko/tobiko.yaml
@@ -1,7 +1,6 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
   TOBIKO_UBUNTU_MINIMAL_IMAGE_URL: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"
-  TOBIKO_VERSION: "master"
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
@@ -29,5 +28,6 @@ tcib_packages:
   - iputils
   - guestfs-tools
   - iperf3
+  - crudini
 
 tcib_user: tobiko


### PR DESCRIPTION
In order to make the Tobiko tcib image more configurable, this patch adds some environment variables that will be relevant for:
- the generated tobiko.conf file
- some variables that will be relevant for tox and pytest, modifying the test execution