### PR TITLE
Run tempest images built in content-provider job

### DIFF
--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -30,6 +30,8 @@
       cifmw_set_openstack_containers_registry: "{{ content_provider_registry_ip }}:5001"
       cifmw_set_openstack_containers_tag_from_md5: true
       cifmw_set_openstack_containers_dlrn_md5_path: "~/ci-framework-data/artifacts/repositories/delorean.repo.md5"
+      cifmw_tempest_registry: "{{ content_provider_registry_ip }}:5001"
+      cifmw_tempest_image_tag: "{{ cifmw_repo_setup_full_hash }}"
 
 - job:
     name: tcib-crc-podified-edpm-baremetal


### PR DESCRIPTION
This change guarantee that job running in this repo are also testing tempest images built in the content-provider job.