### PR TITLE
Add python3-aodhclient

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -17,6 +17,7 @@ tcib_packages:
   - python3-ironicclient
   - python3-manilaclient
   - python3-octaviaclient
+  - python3-aodhclient
   - bash-completion
   - iputils
 tcib_user: cloud-admin


### PR DESCRIPTION
Add the aodhclient to enable the `openstack alarm` commands.