### PR TITLE
Remove deprecated cinderlib from cinder volume

### DIFF
--- a/container-images/tcib/base/os/cinder-base/cinder-volume/cinder-volume.yaml
+++ b/container-images/tcib/base/os/cinder-base/cinder-volume/cinder-volume.yaml
@@ -9,6 +9,5 @@ tcib_actions:
 - run: chmod 755 /usr/local/bin/kolla_extend_start && chmod 440 /etc/sudoers.d/cinder-volume-sudoers
 tcib_packages:
   common:
-  - python3-cinderlib
   - iscsi-initiator-utils
 tcib_user: cinder


### PR DESCRIPTION
Cinderlib is being deprecated [1], so we should stop including it in the cinder-volume container.

[1]: https://review.opendev.org/q/topic:%22deprecate-cinderlib%22