### PR TITLE
Remove python3-observabilityclient

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -16,7 +16,8 @@ tcib_packages:
   - python3-heatclient
   - python3-ironicclient
   - python3-manilaclient
-  - python3-observabilityclient
+  # TODO: Add it back once observability package is available
+  # - python3-observabilityclient
   - python3-octaviaclient
   - python3-aodhclient
   - bash-completion

--- a/container-images/tcib/base/os/os.yaml
+++ b/container-images/tcib/base/os/os.yaml
@@ -11,7 +11,8 @@ tcib_packages:
   - python3-manilaclient
   - python3-neutronclient
   - python3-novaclient
-  - python3-observabilityclient
+  # TODO: Add it back once observability package is available
+  # - python3-observabilityclient
   - python3-octaviaclient
   - python3-openstackclient
   - python3-swiftclient


### PR DESCRIPTION
This package is not yet available as rpm, and it is blocking our promotion pipeline. It should be re-added once the package is ready.