### PR TITLE
Refactor python3-observabilityclient package setup in tcib_packages

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -16,11 +16,16 @@ tcib_packages:
   - python3-heatclient
   - python3-ironicclient
   - python3-manilaclient
-  - python3-observabilityclient
   - python3-octaviaclient
   - python3-aodhclient
   - bash-completion
   - iputils
+  #rhel: We can uncomment this when we have rhel specific pkgs
+  x86_64:
+  - python3-observabilityclient
+  el8:
+  - python3-observabilityclient
+
 tcib_user: cloud-admin
 tcib_workdir: /home/cloud-admin
 # If the container is run directly, start an interactive session


### PR DESCRIPTION
This commit makes two significant changes to tcib pkg configuration:
1. Removes the 'python3-observabilityclient' package from the common configuration. This step is taken to streamline the package setup and tailor the dependencies more specifically to the needs of different architectures and operating systems.
2. Adds the 'python3-observabilityclient' package specifically for x86_64 and el8 architectures. This addition aligns with our strategy to optimize and enhance observability and monitoring capabilities on these architectures.

Additionally, a note is included to address future RHEL-specific package requirements, indicating that RHEL-specific packages can be added or uncommented once they are available.
This change prepares for a more tailored and efficient package management approach in our system configurations.