### PR TITLE
[Tempest][Tobiko] clouds.yaml mounted on the proper path

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -239,7 +239,7 @@ function generate_test_results {
 
 export OS_CLOUD=default
 
-if [ ! -z ${USE_EXTERNAL_FILES} ]; then
+if [ ! -z ${USE_EXTERNAL_FILES} ] && [ ! -f $HOME/.config/openstack/clouds.yaml ]; then
     mkdir -p $HOME/.config/openstack
     cp ${TEMPEST_PATH}clouds.yaml $HOME/.config/openstack/clouds.yaml
 fi

--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+set -x
+
 TOBIKO_DIR=/var/lib/tobiko
 
 # assert mandatory variables have been set
 [ -z ${TOBIKO_TESTENV} ] && echo "TOBIKO_TESTENV not set" && exit 1
 
 # download Ubuntu minimal image used by the Tobiko scenario tests, if needed
-if [ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ]; then
+if [ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ] && [ ! -f ${TOBIKO_DIR}/.downloaded-images/ubuntu-minimal ]; then
     mkdir -p ${TOBIKO_DIR}/.downloaded-images
     curl ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} -o ${TOBIKO_DIR}/.downloaded-images/ubuntu-minimal
 fi
@@ -30,8 +32,10 @@ git checkout ${TOBIKO_VERSION}
 
 # obtain clouds.yaml, id_ecdsa and tobiko.conf from external_files directory
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
-    mkdir -p $TOBIKO_DIR/.config/openstack
-    cp $TOBIKO_DIR/external_files/clouds.yaml $TOBIKO_DIR/.config/openstack/
+    if [ ! -f $TOBIKO_DIR/.config/openstack/clouds.yaml ]; then
+        mkdir -p $TOBIKO_DIR/.config/openstack
+        cp $TOBIKO_DIR/external_files/clouds.yaml $TOBIKO_DIR/.config/openstack/
+    fi
     mkdir -p $TOBIKO_DIR/.ssh
     cp $TOBIKO_DIR/external_files/id_ecdsa* $TOBIKO_DIR/.ssh/
     cp $TOBIKO_DIR/external_files/tobiko.conf .


### PR DESCRIPTION
When either a tempest or a tobiko container is run, the clouds.yaml file could be mounted directly on its proper path
`$HOME/.config/openstack/clouds.yaml` (new behavior implemented in ci-framework) or on the `external_files` directory (legacy behavior).

Related-PR: https://github.com/openstack-k8s-operators/ci-framework/pull/1057

[OSPRH-1670](https://issues.redhat.com//browse/OSPRH-1670)