### PR TITLE
[tempest-extras] Add neutron tempest plugin

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
@@ -8,6 +8,8 @@ tcib_actions:
 - run: cd /usr/local/manila-tempest-plugin; pip install -e .
 - run: cd /usr/local; git clone https://opendev.org/openstack/barbican-tempest-plugin.git
 - run: cd /usr/local/barbican-tempest-plugin; pip install -e .
+- run: cd /usr/local; git clone https://opendev.org/openstack/neutron-tempest-plugin.git
+- run: cd /usr/local/neutron-tempest-plugin; pip install -e .
 
 tcib_packages:
   common:


### PR DESCRIPTION
Add the neutron tempest plugin [1] to allow for more specific neutron coverage in network CI component pipeline.

[1] https://opendev.org/openstack/neutron-tempest-plugin