### PR TITLE
Re-add python3-observabilityclient

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -16,8 +16,7 @@ tcib_packages:
   - python3-heatclient
   - python3-ironicclient
   - python3-manilaclient
-  # TODO: Add it back once observability package is available
-  # - python3-observabilityclient
+  - python3-observabilityclient
   - python3-octaviaclient
   - python3-aodhclient
   - bash-completion

--- a/container-images/tcib/base/os/os.yaml
+++ b/container-images/tcib/base/os/os.yaml
@@ -11,8 +11,7 @@ tcib_packages:
   - python3-manilaclient
   - python3-neutronclient
   - python3-novaclient
-  # TODO: Add it back once observability package is available
-  # - python3-observabilityclient
+  - python3-observabilityclient
   - python3-octaviaclient
   - python3-openstackclient
   - python3-swiftclient


### PR DESCRIPTION
We do have now a build in downstream, so we can enable it again