### PR TITLE
[ironic] Add httpd/mod_ssl to ironic-inspector image

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
@@ -3,6 +3,8 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 tcib_packages:
   common:
+  - httpd
+  - mod_ssl
   - openstack-ironic-inspector
   - openstack-ironic-inspector-dnsmasq
 tcib_user: ironic-inspector


### PR DESCRIPTION
To be able to terminate TLS using httpd.

Jira: [OSPRH-4220](https://issues.redhat.com//browse/OSPRH-4220)