### PR TITLE
Skip unnecessary TLS cert creation on container startup

### DIFF
--- a/container-images/kolla/base/httpd_setup.sh
+++ b/container-images/kolla/base/httpd_setup.sh
@@ -14,7 +14,8 @@ if [[ "$(whoami)" == 'root' ]]; then
     # on startup:
     #   SSLCertificateFile: file '/etc/pki/tls/certs/localhost.crt' does not exist or is empty
     # Work around this by generating certificates manually.
-    if [[ ! -e /etc/pki/tls/certs/localhost.crt ]]; then
+    if grep -q -E '^SSLCertificateFile \/etc\/pki\/tls\/certs\/localhost\.crt$' /etc/httpd/conf.d/ssl.conf && \
+            [[ ! -e /etc/pki/tls/certs/localhost.crt ]]; then
         /usr/libexec/httpd-ssl-gencerts
     fi
 fi


### PR DESCRIPTION
Kolla is generating a self-signed cert on container startup which we do not use. This will burn considerable resources and time for every container start.
If we have mounted a custom ssl.conf skip the step.