### PR TITLE
[tempest] Fix parsing of TEMPESTCONF_{REMOVE,APPEND}

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -150,13 +150,17 @@ IFS=$OLD_IFS
 
 if [[ ! -z ${TEMPESTCONF_APPEND} ]]; then
     while IFS= read -r line; do
-        TEMPESTCONF_ARGS+="--append $line "
+        [[ ! -n "$line" ]] && continue
+        arr_line=( $line )
+        TEMPESTCONF_ARGS+="--append ${arr_line[0]}=${arr_line[1]} "
     done <<< "$TEMPESTCONF_APPEND"
 fi
 
 if [[ ! -z ${TEMPESTCONF_REMOVE} ]]; then
     while IFS= read -r line; do
-        TEMPESTCONF_ARGS+="--remove $line "
+        [[ ! -n "$line" ]] && continue
+        arr_line=( $line )
+        TEMPESTCONF_ARGS+="--remove ${arr_line[0]}=${arr_line[1]} "
     done <<< "$TEMPESTCONF_REMOVE"
 fi
 


### PR DESCRIPTION
If there is a new line at the end of either TEMPESTCONF_REMOVE or TEMPESTCONF_APPEND then it might happen that the run_tempest.sh adds --remove/--append parameter to the tempest command with an empty value.

For example:
TEMPESTCONF_REMOVE="section.subsection False
" # <-- New line

leads to:
tempest run --remove section.subsection False --remove


Also, both --remove and --append expect '=' between section name and
value [1].