### PR TITLE
[Tobiko] Add tcpdump and prepare to run containers as root

### DIFF
--- a/container-images/tcib/base/os/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/os/tobiko/run_tobiko.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+set -x
+
 TOBIKO_DIR=/var/lib/tobiko
 
 # assert mandatory variables have been set
-[ -z ${TOBIKO_TESTENV} ] && echo "TOBIKO_TESTENV not set" && exit 1
+[ -z "${TOBIKO_TESTENV}" ] && echo "TOBIKO_TESTENV not set" && exit 1
 
 # download Ubuntu minimal image used by the Tobiko scenario tests, if needed
 if [ ! -z ${TOBIKO_UBUNTU_MINIMAL_IMAGE_URL} ]; then
@@ -13,6 +15,7 @@ fi
 
 # set default values for the required variables
 TOBIKO_VERSION=${TOBIKO_VERSION:-master}
+TOBIKO_PRIVATE_KEY_FILE=${TOBIKO_PRIVATE_KEY_FILE:-id_ecdsa}
 
 # export OS_CLOUD variable
 [ ! -z ${TOBIKO_OS_CLOUD} ] && export OS_CLOUD=${TOBIKO_OS_CLOUD} || export OS_CLOUD=default
@@ -21,19 +24,20 @@ TOBIKO_VERSION=${TOBIKO_VERSION:-master}
 [ ! -z ${TOBIKO_PYTEST_ADDOPTS} ] && export PYTEST_ADDOPTS=${TOBIKO_PYTEST_ADDOPTS}
 [ ! -z ${TOBIKO_RUN_TESTS_TIMEOUT} ] && export TOX_RUN_TESTS_TIMEOUT=${TOBIKO_RUN_TESTS_TIMEOUT}
 [ ! -z ${TOBIKO_PREVENT_CREATE} ] && export TOBIKO_PREVENT_CREATE=${TOBIKO_PREVENT_CREATE}
-[ ! -z ${TOBIKO_NUM_PROCESSES} ] && export=TOX_NUM_PROCESSES=${TOBIKO_NUM_PROCESSES}
+[ ! -z ${TOBIKO_NUM_PROCESSES} ] && export TOX_NUM_PROCESSES=${TOBIKO_NUM_PROCESSES}
 
 pushd ${TOBIKO_DIR}
 git clone https://opendev.org/x/tobiko
 pushd tobiko
 git checkout ${TOBIKO_VERSION}
 
-# obtain clouds.yaml, id_ecdsa and tobiko.conf from external_files directory
+# obtain clouds.yaml, ssh private/public keys and tobiko.conf from external_files directory
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     mkdir -p $TOBIKO_DIR/.config/openstack
     cp $TOBIKO_DIR/external_files/clouds.yaml $TOBIKO_DIR/.config/openstack/
     mkdir -p $TOBIKO_DIR/.ssh
-    cp $TOBIKO_DIR/external_files/id_ecdsa* $TOBIKO_DIR/.ssh/
+    sudo cp $TOBIKO_DIR/external_files/${TOBIKO_PRIVATE_KEY_FILE}* $TOBIKO_DIR/.ssh/
+    sudo chown tobiko:tobiko $TOBIKO_DIR/.ssh/${TOBIKO_PRIVATE_KEY_FILE}*
     cp $TOBIKO_DIR/external_files/tobiko.conf .
 fi
 
@@ -45,8 +49,8 @@ RETURN_VALUE=$?
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     echo "Copying logs file"
     LOG_DIR=${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/py3/log}
-    cp -rf ${LOG_DIR} ${TOBIKO_DIR}/external_files/
-    cp tobiko.conf ${TOBIKO_DIR}/external_files/
+    sudo cp -rf ${LOG_DIR} ${TOBIKO_DIR}/external_files/
+    sudo cp tobiko.conf ${TOBIKO_DIR}/external_files/
 fi
 
 exit ${RETURN_VALUE}

--- a/container-images/tcib/base/os/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/os/tobiko/tobiko.yaml
@@ -28,5 +28,6 @@ tcib_packages:
   - iputils
   - guestfs-tools
   - iperf3
+  - tcpdump
 
 tcib_user: tobiko


### PR DESCRIPTION
Some tobiko tests capture traffic on the tobiko container where tests are executed using tcpdump.

For that reason:
- tcpdump needs to be added to the list of packages that need to be installed on the tobiko image.
- the container will need to be executed with root permissions, so the run_tobiko.sh script needs to manage properly the mounted files and directories.