### PR TITLE
[tempest] Install external plugins using upper-constraints

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -188,7 +188,7 @@ function run_git_tempest {
             popd
         fi
 
-        pip install ./$plugin_name
+        pip install -chttps://releases.openstack.org/constraints/upper/2023.1 ./$plugin_name
     done
 
     pushd $HOMEDIR


### PR DESCRIPTION
Use upper-constraints that match the version of tempest being run. This avoids incompatabilities caused by pip installing the latest versions of the dependencies.