### PR TITLE
pin libvirt-libs due to RHEL-20609

### DIFF
--- a/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
+++ b/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
@@ -25,4 +25,5 @@ tcib_packages:
   - swtpm-tools
   - targetcli
   - xfsprogs
+  - "libvirt-libs\<9.10.0"
 tcib_user: nova


### PR DESCRIPTION
This pins libvirt-libs to <9.10 to avoid
a unicode parseing bug that breaks nova.
