### PR TITLE
Removing libvirt downgrade

### DIFF
--- a/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
+++ b/container-images/tcib/base/os/nova-base/nova-compute/nova-compute.yaml
@@ -3,8 +3,6 @@ tcib_actions:
 # this need to happen after installing nova-compute because the distgit does usermod to add libvirt/qemu groups
 - run: bash /usr/local/bin/uid_gid_manage nova
 - run: rm -f /etc/machine-id
-- run: >-
-    if [ '{{ tcib_distro }}' == 'centos' ];then dnf -y install 'libvirt-libs < 9.10.0' && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: if [ -f /usr/share/qemu/firmware/50-edk2-ovmf-cc.json ] && [ -f /usr/share/qemu/firmware/50-edk2-ovmf-amdsev.json ]; then jq ".mapping[\"nvram-template\"] = $(jq ".mapping[\"nvram-template\"]" /usr/share/qemu/firmware/50-edk2-ovmf-cc.json)" /usr/share/qemu/firmware/50-edk2-ovmf-amdsev.json > /tmp/50-edk2-ovmf-amdsev_.json && mv -f /tmp/50-edk2-ovmf-amdsev_.json /usr/share/qemu/firmware/50-edk2-ovmf-amdsev.json; fi
 tcib_packages:
   common:


### PR DESCRIPTION
libvirt 10 landed on CentOS stream so this downgrade is no longer required.