### PR TITLE
[Tempest-all] Configure path to octavia test server 

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -121,7 +121,13 @@ TEMPEST_ARGS=""
 [[ ! -z ${TEMPESTCONF_FLAVOR_MIN_DISK} ]] && TEMPESTCONF_ARGS+="--flavor-min-disk ${TEMPESTCONF_FLAVOR_MIN_DISK} "
 [[ ! -z ${TEMPESTCONF_NETWORK_ID} ]] && TEMPESTCONF_ARGS+="--network-id ${TEMPESTCONF_NETWORK_ID} "
 
-TEMPESTCONF_OVERRIDES="$(echo ${TEMPESTCONF_OVERRIDES} | tr '\n' ' ') identity.v3_endpoint_type public"
+TEMPESTCONF_OVERRIDES="$(echo ${TEMPESTCONF_OVERRIDES} | tr '\n' ' ') identity.v3_endpoint_type public "
+
+# Octavia test-server is built as part of the installation of the python3-octavia-tests-tempest
+# https://github.com/rdo-packages/octavia-tempest-plugin-distgit/blob/rpm-master/python-octavia-tests-tempest.spec#L127
+if [[ ! -z ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH} ]]; then
+    TEMPESTCONF_OVERRIDES+="load_balancer.test_server_path ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH}"
+fi
 
 # Tempest arguments
 TEMPEST_EXTERNAL_PLUGIN_GIT_URL="${TEMPEST_EXTERNAL_PLUGIN_GIT_URL:-}"

--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -1,5 +1,6 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
+  TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH: /usr/libexec/octavia-tempest-plugin-tests-httpd
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
python3-octavia-tempest-plugin rpm builds the go test server during the
installation [1]. This patch ensures that the tempest-all image by
default sets the path to the test server binary in tempest.conf in case
it is needed by octavia-tempest-plugin.

[1] https://github.com/rdo-packages/octavia-tempest-plugin-distgit/blob/rpm-master/python-octavia-tests-tempest.spec#L127

