### PR TITLE
Set cifmw_repo_setup_output to /etc/yum.repos.d

### DIFF
--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -5,6 +5,8 @@
     vars:
       cifmw_build_containers_registry_namespace: podified-antelope-centos9
       cifmw_build_containers_install_from_source: true
+      cifmw_repo_setup_output: "/etc/yum.repos.d"
+      cifmw_build_containers_repo_dir:  "{{ cifmw_repo_setup_output }}"
     irrelevant-files: &if
       - HACKING.rst
       - AUTHORS


### PR DESCRIPTION
Workaround needed because the job doesn't find the delorean.repo.md5 file.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1194