### PR TITLE
[tobiko] install tox version from RPM 

### DIFF
--- a/container-images/tcib/base/os/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/os/tobiko/tobiko.yaml
@@ -8,8 +8,6 @@ tcib_actions:
 - run: chmod 440 /etc/sudoers.d/tobiko_sudoers
 - run: mkdir -p /var/lib/tempest/external_files
 - run: chown -R tobiko.tobiko /var/lib/tobiko
-- run: python3 -m pip install --upgrade pip
-- run: python3 -m pip install 'tox>=3.8,<4.0'
 - run: cp /usr/share/tcib/container-images/tcib/base/os/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
 - run: chmod +x /var/lib/tobiko/run_tobiko.sh
 
@@ -22,6 +20,7 @@ tcib_packages:
   - python3
   - python3-devel
   - python3-pip
+  - python3-tox
   - which
   - findutils
   - iproute


### PR DESCRIPTION
Stop installing tox with pip and install tox from an RPM instead.
The tox version installed via RPM is valid for tobiko, since it's higher
than 3.8.
With this change a vulnerability issue affecting the tobiko image is
resolved:
https://github.com/advisories/GHSA-w596-4wvx-j9j6

[OSPRH-5225](https://issues.redhat.com//browse/OSPRH-5225)