### PR TITLE
Remove pysnmp from explicit list of packages in ironic-conductor

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -14,7 +14,6 @@ tcib_packages:
   - psmisc
   - python3-dracclient
   - python3-proliantutils
-  - python3-pysnmp
   - python3-scciclient
   - python3-sushy
   - python3-systemd


### PR DESCRIPTION
During Caracal release, ironic, proliantutils and scciclient have moved to pysnmp-lextudio fork to replace the unmaintained pysnmp.

In order to make this container file compatible with both antelope and master, we can symply remove pysnmp from the explicit list of packages and simply let proliantutils and scciclient to pull the right package for each release.