### PR TITLE
Install iproute in ironic-inspector container

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
@@ -7,4 +7,5 @@ tcib_packages:
   - mod_ssl
   - openstack-ironic-inspector
   - openstack-ironic-inspector-dnsmasq
+  - iproute
 tcib_user: ironic-inspector


### PR DESCRIPTION
The ss command is used in the probe.

```
5m57s  Warning  Unhealthy  pod/ironic-inspector-0   Readiness probe failed: sh: line 1: ss: command not found
```