### PR TITLE
[Tobiko] Pin tox to 4.13

### DIFF
--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -8,8 +8,11 @@ tcib_actions:
 - run: chmod 440 /etc/sudoers.d/tobiko_sudoers
 - run: mkdir -p /var/lib/tempest/external_files
 - run: chown -R tobiko.tobiko /var/lib/tobiko
+- run: >-
+    if [ '{{ tcib_distro }}' == 'rhel' ];then
+    if [ -n "$(rpm -qa redhat-release)" ];then dnf -y remove python3-chardet; fi ; fi
 - run: python3 -m pip install --upgrade pip
-- run: python3 -m pip install 'tox>=4.13'
+- run: python3 -m pip install 'tox==4.13'
 - run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
 - run: chmod +x /var/lib/tobiko/run_tobiko.sh
 

--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -2,6 +2,7 @@
 - job:
     name: tcib-build-containers
     parent: cifmw-tcib-base
+    nodeset: centos-stream-9-vexxhost
     vars:
       cifmw_build_containers_registry_namespace: podified-antelope-centos9
       cifmw_build_containers_install_from_source: true


### PR DESCRIPTION
Before this patch, tox version >=4.13 was installed using pip, but that caused some incompatibility issues with dependencies that were installed via RPM (pip could not update versions).

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1254