### PR TITLE
[Tobiko] Fix extraction of log dir name

### DIFF
--- a/container-images/tcib/base/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/tobiko/run_tobiko.sh
@@ -58,7 +58,8 @@ RETURN_VALUE=$?
 # copy logs to external_files
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     echo "Copying logs file"
-    LOG_DIR=${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/${TOBIKO_TESTENV}/log}
+    TOBIKO_TESTENV_ARR=($TOBIKO_TESTENV)
+    LOG_DIR=${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/${TOBIKO_TESTENV_ARR}/log}
     sudo cp -rf ${LOG_DIR} ${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/
     if [ -f tobiko.conf ]; then
         sudo cp tobiko.conf ${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/


### PR DESCRIPTION
Currently we look for the logs based on the name of testenv but we do not take into account the fact that the testenv can have the following format:

'functional -- tobiko/tests/functional/podified/test_topology.py'

This patch ensures that we take only the first part of the testenv name ('functional') into account when copying the logs.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1254