### PR TITLE
Drop openstack-ironic-staging-drivers from ironic-condutor

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -9,7 +9,6 @@ tcib_packages:
   - ipmitool
   - openssh-clients
   - openstack-ironic-conductor
-  - openstack-ironic-staging-drivers
   - parted
   - psmisc
   - python3-dracclient


### PR DESCRIPTION
https://issues.redhat.com/browse/OSPRH-5427 drops the openstack-ironic-staging-drivers from OSP-18 and package is removed from downstream dlrn builds, leading to failure in building ironic conductor container image.

Dropping this package from tcib fixes the issue.
