### PR TITLE
[Tempest-all] Add support for oc command

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -259,6 +259,10 @@ function generate_test_results {
 
 export OS_CLOUD=default
 
+if [ ! -z ${TEMPEST_OCP_CLIENT_TGZ} ]; then
+    which oc || curl -s -L ${TEMPEST_OCP_CLIENT_TGZ} | sudo tar -zxvf - -C /usr/local/bin/
+fi
+
 if [ ! -z ${USE_EXTERNAL_FILES} ]; then
     mkdir -p $HOME/.config/openstack
     cp ${TEMPEST_PATH}clouds.yaml $HOME/.config/openstack/clouds.yaml

--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -1,6 +1,7 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
   TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH: /usr/libexec/octavia-tempest-plugin-tests-httpd
+  TEMPEST_OCP_CLIENT_TGZ: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
Whitebox-neutron-tempest-plugin requires oc command to be able to execute certain tests. This patch makes sure that oc is part of the tempest-all image.