### PR TITLE
Install syslinux-nonlinux in ironic explicitly

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -17,6 +17,7 @@ tcib_packages:
   - python3-sushy
   - python3-systemd
   - qemu-img
+  - syslinux-nonlinux
   - util-linux
   - xfsprogs
 tcib_user: ironic


### PR DESCRIPTION
The syslinux-nonlinux package is now recommended and not required.

See https://review.rdoproject.org/r/c/openstack/ironic-distgit/+/51902