### PR TITLE
[Tempest] Introduce workflow dir

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -95,6 +95,7 @@ CONCURRENCY="${CONCURRENCY:-}"
 TEMPESTCONF_ARGS=""
 TEMPEST_ARGS=""
 
+[[ -z ${TEMPEST_WORKFLOW_STEP_DIR_NAME} ]] && TEMPEST_WORKFLOW_STEP_DIR_NAME="tempest"
 [[ ! -z ${USE_EXTERNAL_FILES} ]] && TEMPEST_PATH=$HOMEDIR/external_files/
 
 [[ ${TEMPESTCONF_CREATE:=true} == true ]] && TEMPESTCONF_ARGS+="--create "
@@ -242,17 +243,20 @@ function generate_test_results {
         cat ${TEMPEST_INCLUDE_LIST}
     fi
 
+    TEMPEST_LOGS_DIR=${TEMPEST_PATH}${TEMPEST_WORKFLOW_STEP_DIR_NAME}/
+    mkdir -p ${TEMPEST_LOGS_DIR}
+
     echo "Generate subunit"
-    stestr last --subunit > ${TEMPEST_PATH}testrepository.subunit || true
+    stestr last --subunit > ${TEMPEST_LOGS_DIR}testrepository.subunit || true
 
     echo "Generate subunit xml file"
-    subunit2junitxml ${TEMPEST_PATH}testrepository.subunit > ${TEMPEST_PATH}tempest_results.xml || true
+    subunit2junitxml ${TEMPEST_LOGS_DIR}testrepository.subunit > ${TEMPEST_LOGS_DIR}tempest_results.xml || true
 
     echo "Generate html result"
-    subunit2html ${TEMPEST_PATH}testrepository.subunit ${TEMPEST_PATH}stestr_results.html || true
+    subunit2html ${TEMPEST_LOGS_DIR}testrepository.subunit ${TEMPEST_LOGS_DIR}stestr_results.html || true
 
     echo Copying logs file
-    cp -rf ${TEMPEST_DIR}/* ${TEMPEST_PATH}
+    cp -rf ${TEMPEST_DIR}/* ${TEMPEST_LOGS_DIR}
 
     popd
 }


### PR DESCRIPTION
Tempest workflows are introduced together with this change in the test-operator [1]. This change adds a variable that can be used to specify name of a directory where logs for a specific workflow step are stored.

[1] https://github.com/openstack-k8s-operators/test-operator/pull/67