### PR TITLE
Fix private key permission

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -276,6 +276,16 @@ if [ ! -f ${TEMPEST_PATH}exclude.txt ] && [ -z ${TEMPEST_EXCLUDE_LIST} ]; then
     touch ${TEMPEST_PATH}exclude.txt
 fi
 
+# This workaround is required for the whitebox-neutron-tempest plugin. We need
+# to be able to specify 600 permissions for the id_ecdsa.
+if [ -f ${HOMEDIR}/id_ecdsa ]; then
+    mkdir -p ${HOMEDIR}/.ssh
+    cp ${HOMEDIR}/id_ecdsa ${HOMEDIR}/.ssh/id_ecdsa
+    sudo chmod 700 ${HOMEDIR}/.ssh
+    sudo chmod 600 ${HOMEDIR}/.ssh/id_ecdsa
+    sudo chown -R tempest:tempest ${HOMEDIR}/.ssh
+fi
+
 if [ -z $TEMPEST_EXTERNAL_PLUGIN_GIT_URL ]; then
     run_rpm_tempest
 else


### PR DESCRIPTION
It seems that there is no direct way how to set 600 for a mounted secret using openshift. This patch creates a workoround that copies the mounted secret (private key) to the correct destination and sets the correct permissions for it.