### PR TITLE
Add ipmitool to openstackclient base image

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -22,6 +22,7 @@ tcib_packages:
   - python3-aodhclient
   - bash-completion
   - iputils
+  - ipmitool
 tcib_user: cloud-admin
 tcib_workdir: /home/cloud-admin
 # If the container is run directly, start an interactive session


### PR DESCRIPTION
Having ipmitool in the client image could be useful for troubleshooting purposes as well as allowing us to re-use the client image for things like Instance HA, avoiding the burden of having to maintain another dedicated image.