### PR TITLE
Add space to test_server_patch octavia override section

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -127,7 +127,7 @@ TEMPESTCONF_OVERRIDES="$(echo ${TEMPESTCONF_OVERRIDES} | tr '\n' ' ') identity.v
 # Octavia test-server is built as part of the installation of the python3-octavia-tests-tempest
 # https://github.com/rdo-packages/octavia-tempest-plugin-distgit/blob/rpm-master/python-octavia-tests-tempest.spec#L127
 if [[ ! -z ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH} ]]; then
-    TEMPESTCONF_OVERRIDES+="load_balancer.test_server_path ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH}"
+    TEMPESTCONF_OVERRIDES+="load_balancer.test_server_path ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH} "
 fi
 
 # Tempest arguments
@@ -201,7 +201,7 @@ function generate_extra_tempest_configuration {
     fi
 
     TEMPESTCONF_OVERRIDES+="neutron_plugin_options.advanced_image_ref ${TEMPEST_NEUTRON_IMAGE_ID} "
-    TEMPESTCONF_OVERRIDES+="neutron_plugin_options.advanced_image_flavor_ref ${TEMPEST_NEUTRON_FLAVOR_ID}"
+    TEMPESTCONF_OVERRIDES+="neutron_plugin_options.advanced_image_flavor_ref ${TEMPEST_NEUTRON_FLAVOR_ID} "
 }
 
 function run_git_tempest {


### PR DESCRIPTION
We do not add a space at the end of the test_server_patch tempestconf override option. This breaks the discover-tempest-config generation when TEMPEST_NEUTRON_IMAGE_URL is set.