### PR TITLE
[Tobiko] Download tobiko repo, oc and ubuntu image during image creation

### DIFF
--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -1,6 +1,5 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
-  TOBIKO_UBUNTU_MINIMAL_IMAGE_URL: "https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
@@ -11,6 +10,15 @@ tcib_actions:
 - run: >-
     if [ '{{ tcib_distro }}' == 'rhel' ];then
     if [ -n "$(rpm -qa redhat-release)" ];then dnf -y remove python3-chardet; fi ; fi
+- run: >-
+    curl -s -L
+    https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
+    | tar -zxvf - -C /usr/local/bin/
+- run: 'git clone https://opendev.org/x/tobiko /var/lib/tobiko/tobiko'
+- run: >-
+    mkdir -p /var/lib/tobiko/.downloaded-images && curl
+    https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
+    -o /var/lib/tobiko/.downloaded-images/ubuntu-minimal
 - run: python3 -m pip install --upgrade pip
 - run: python3 -m pip install 'tox==4.13'
 - run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh


### PR DESCRIPTION
The tobiko repo, the openshift client (oc) and the ubuntu image
were downloaded when the tobiko container started running, before this
patch.
After this patch, those operations will be performed during the image
creation, so when the container starts running tobiko, oc and ubuntu
image will already be available.

[OSPRH-6347](https://issues.redhat.com//browse/OSPRH-6347)