### PR TITLE
Fix advanced image creation

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -188,7 +188,7 @@ function generate_extra_tempest_configuration {
                 --os-cloud default \
                 --disk-format qcow2 \
                 --container-format bare \
-                --file "$TEMPEST_NEUTRON_IMAGE.qcow2" ${TEMPEST_NEUTRON_IMAGE}
+                --file "$TEMPEST_NEUTRON_IMAGE.qcow2" --public ${TEMPEST_NEUTRON_IMAGE}
     fi
     TEMPEST_NEUTRON_IMAGE_ID=$(openstack image list --os-cloud default --name ${TEMPEST_NEUTRON_IMAGE} -f value -c ID)
 


### PR DESCRIPTION
Currently, the run_tempest.sh creates the advanced image without --public. This can cause failures as users created by tempest can not discover the created image.