### PR TITLE
glance-api: install python3-boto3 as to support s3

### DIFF
--- a/container-images/tcib/base/os/glance-api/glance-api.yaml
+++ b/container-images/tcib/base/os/glance-api/glance-api.yaml
@@ -10,6 +10,7 @@ tcib_packages:
   - mod_ssl
   - iscsi-initiator-utils
   - openstack-glance
+  - python3-boto3
   - python3-rados
   - python3-rbd
   - qemu-img


### PR DESCRIPTION
This dependency is required for users trying to use the s3 backend.
