### PR TITLE
[tempest] TEMPEST_PARALLEL shouldn't have default

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -173,7 +173,7 @@ read -ra TEMPEST_EXTRA_IMAGES_FLAVOR_OS_CLOUD <<< $TEMPEST_EXTRA_IMAGES_FLAVOR_O
 IFS=$OLD_IFS
 
 [[ ${TEMPEST_SMOKE} == true ]] && TEMPEST_ARGS+="--smoke "
-[[ ${TEMPEST_PARALLEL:=true} == true ]] && TEMPEST_ARGS+="--parallel "
+[[ ${TEMPEST_PARALLEL} == true ]] && TEMPEST_ARGS+="--parallel "
 [[ ${TEMPEST_SERIAL} == true ]] && TEMPEST_ARGS+="--serial "
 
 [[ ! -z ${TEMPEST_INCLUDE_LIST} ]] && TEMPEST_ARGS+="--include-list ${TEMPEST_INCLUDE_LIST} "


### PR DESCRIPTION
TEMPEST_PARALLEL variable should not have a default value set. Tempest has a default value, setting another default value in, basically, a wrapper introduces unnecessary edge cases, e.g. if someone sets TEMPEST_SERIAL and doesn't notice that TEMPEST_PARALLEL has a default value, it will result in setting both (--serial and --parallel) and Tempest will fail on that.