### PR TITLE
Don't run Tempest if discover failed

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -300,8 +300,8 @@ function run_git_tempest {
     tempest init openshift
     pushd $TEMPEST_DIR
 
-    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES}
-    tempest run ${TEMPEST_ARGS}
+    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 
     deactivate
@@ -319,8 +319,8 @@ function run_rpm_tempest {
     # Install additional plugins from .rpms plus their dependencies
     [ ${#TEMPEST_EXTRA_RPMS[@]} -ne 0 ] && sudo dnf install -y ${TEMPEST_EXTRA_RPMS[@]}
 
-    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES}
-    tempest run ${TEMPEST_ARGS}
+    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 
     popd


### PR DESCRIPTION
Tempest run requires a tempest.conf, without it, it does not make sense to run Tempest. If discover-tempest-config fails for any reason, we should not run tempest to save execution time.