### PR TITLE
Move setting tobiko dir owner to the last action

### DIFF
--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -6,7 +6,6 @@ tcib_actions:
 - run: cp /usr/share/tcib/container-images/tcib/base/tobiko/tobiko_sudoers /etc/sudoers.d/tobiko_sudoers
 - run: chmod 440 /etc/sudoers.d/tobiko_sudoers
 - run: mkdir -p /var/lib/tempest/external_files
-- run: chown -R tobiko.tobiko /var/lib/tobiko
 - run: >-
     if [ '{{ tcib_distro }}' == 'rhel' ];then
     if [ -n "$(rpm -qa redhat-release)" ];then dnf -y remove python3-chardet; fi ; fi
@@ -23,6 +22,7 @@ tcib_actions:
 - run: python3 -m pip install 'tox==4.13'
 - run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
 - run: chmod +x /var/lib/tobiko/run_tobiko.sh
+- run: chown -R tobiko.tobiko /var/lib/tobiko
 
 tcib_entrypoint: /var/lib/tobiko/run_tobiko.sh
 


### PR DESCRIPTION
After the owner of the tobiko home directory (/var/lib/tobiko) was set, some other actions like creating a subdir were done using the root user.
This patch moves the action that sets the owner of that directory and its subdirectories to the end of the list of actions.