### PR TITLE
Remove parallel option

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -43,7 +43,7 @@
 # responsible for the tempest tests execution.
 #
 # Supported boolean arguments:
-#   --smoke, --parallel, --serial
+#   --smoke, --serial
 #
 # Supported string arguments:
 #   --include-list, --exclude-list, --concurrency, --worker-file,
@@ -187,7 +187,6 @@ read -ra TEMPEST_EXTRA_IMAGES_FLAVOR_OS_CLOUD <<< $TEMPEST_EXTRA_IMAGES_FLAVOR_O
 IFS=$OLD_IFS
 
 [[ ${TEMPEST_SMOKE} == true ]] && TEMPEST_ARGS+="--smoke "
-[[ ${TEMPEST_PARALLEL} == true ]] && TEMPEST_ARGS+="--parallel "
 [[ ${TEMPEST_SERIAL} == true ]] && TEMPEST_ARGS+="--serial "
 
 [[ ! -z ${TEMPEST_INCLUDE_LIST} ]] && TEMPEST_ARGS+="--include-list ${TEMPEST_INCLUDE_LIST} "


### PR DESCRIPTION
parallel option is default behavior of tempest and there is no need to specify it.