### PR TITLE
Add ceph-common to Glance container

### DIFF
--- a/container-images/tcib/base/os/glance-api/glance-api.yaml
+++ b/container-images/tcib/base/os/glance-api/glance-api.yaml
@@ -14,4 +14,5 @@ tcib_packages:
   - python3-rados
   - python3-rbd
   - qemu-img
+  - ceph-common
 tcib_user: glance


### PR DESCRIPTION
As done for `Cinder`, we add the `ceph-common` package to `glanceAPI` to make the troubleshooting against the `Ceph` cluster easier. `Glance` is attached to the `storage` network and usually it already has the required `ceph` config.

Jira: https://issues.redhat.com/browse/OSPRH-839