### PR TITLE
Exclude setuptools 71.0.0

### DIFF
--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -26,6 +26,7 @@ tcib_packages:
   - xorg-x11-server-Xvfb
   - firefox
   pip_packages:
+  - setuptools!=71.0.0
   - pytest==7.3.2
   - pytest-django
   - pytest-html


### PR DESCRIPTION
Recent release of setuptools break xvfbwrapper installation with following error:
```
× Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [38 lines of output]
      running egg_info
      Traceback (most recent call last):
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 25, in <module>
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 106, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 970, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 974, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.ensure_finalized()
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 111, in ensure_finalized
          self.finalize_options()
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 258, in finalize_options
          key = getattr(pd, "key", None) or getattr(pd, "name", None)
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 460, in name
          return self.metadata['Name']
        File "/tmp/pip-build-env-t0f7tyoe/overlay/lib/python3.9/site-packages/setuptools/_vendor/importlib_metadata/_adapters.py", line 54, in __getitem__
          raise KeyError(item)
      KeyError: 'Name'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```
Excluding setuptools 71.0.0 fixes the issue.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2115