### PR TITLE
Fix Horizontest pod exit

### DIFF
--- a/container-images/tcib/base/os/horizontest/run_horizontest.sh
+++ b/container-images/tcib/base/os/horizontest/run_horizontest.sh
@@ -134,3 +134,5 @@ mkdir -p ${LOG_DIR}
 sudo cp -rf ${HORIZONTEST_DIR}/horizon/test_reports/* ${LOG_DIR}
 
 delete_custom_resources
+
+exit ${RETURN_VALUE}


### PR DESCRIPTION
We need to make sure Horizontest pod exits correctly , based on the exit value the pod either fails or succeeds . This patch fixed that part 