### PR TITLE
[Tempest] Remove cirros image from logs

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -352,6 +352,9 @@ function generate_test_results {
     echo "Generate html result"
     subunit2html ${TEMPEST_LOGS_DIR}testrepository.subunit ${TEMPEST_LOGS_DIR}stestr_results.html || true
 
+    # NOTE: Remove cirros image before copying of the logs.
+    rm ${TEMPEST_DIR}/etc/*.img
+
     echo Copying logs file
     cp -rf ${TEMPEST_DIR}/* ${TEMPEST_LOGS_DIR}
 


### PR DESCRIPTION
Up until now we were collecting cirros image that is downloaded during the discover-tempest-config phase into the logs folder. The cirros image is not needed artifact and in some edge cases it might happen that the cirros file is too big for it to be stored in the external PV.

This patch removes the cirros image before the logs are collected.