### PR TITLE
[Tempest] Modify IMAGES_TIMEOUT for individual images

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -95,7 +95,6 @@ CONCURRENCY="${CONCURRENCY:-}"
 TEMPESTCONF_ARGS=""
 TEMPEST_ARGS=""
 TEMPEST_DEBUG_MODE="${TEMPEST_DEBUG_MODE:-false}"
-TEMPEST_IMAGE_CREATE_TIMEOUT="${TEMPEST_IMAGE_CREATE_TIMEOUT:-300}"
 
 function catch_error_if_debug {
     echo "File run_tempest.sh has run into an error!"
@@ -163,6 +162,7 @@ TEMPEST_EXTRA_IMAGES_FLAVOR_DISK="${TEMPEST_EXTRA_IMAGES_FLAVOR_DISK:-}"
 TEMPEST_EXTRA_IMAGES_FLAVOR_VCPUS="${TEMPEST_EXTRA_IMAGES_FLAVOR_VCPUS:-}"
 TEMPEST_EXTRA_IMAGES_FLAVOR_NAME="${TEMPEST_EXTRA_IMAGES_FLAVOR_NAME:-}"
 TEMPEST_EXTRA_IMAGES_FLAVOR_OS_CLOUD="${TEMPEST_EXTRA_IMAGES_FLAVOR_OS_CLOUD:-}"
+TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT="${TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT:-}"
 
 # Convert comma separated lists to arrays
 OLD_IFS=$IFS
@@ -178,6 +178,7 @@ read -ra TEMPEST_EXTRA_IMAGES_OS_CLOUD <<< $TEMPEST_EXTRA_IMAGES_OS_CLOUD
 read -ra TEMPEST_EXTRA_IMAGES_ID <<< $TEMPEST_EXTRA_IMAGES_ID
 read -ra TEMPEST_EXTRA_IMAGES_NAME <<< $TEMPEST_EXTRA_IMAGES_NAME
 read -ra TEMPEST_EXTRA_IMAGES_CONTAINER_FORMAT <<< $TEMPEST_EXTRA_IMAGES_CONTAINER_FORMAT
+read -ra TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT <<< $TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT
 
 read -ra TEMPEST_EXTRA_IMAGES_FLAVOR_ID <<< $TEMPEST_EXTRA_IMAGES_FLAVOR_ID
 read -ra TEMPEST_EXTRA_IMAGES_FLAVOR_RAM <<< $TEMPEST_EXTRA_IMAGES_FLAVOR_RAM
@@ -252,8 +253,8 @@ function upload_extra_images {
             while [ "$STATUS" != "active" ]; do
                 echo "Current status: $STATUS. Waiting for image to become active..."
                 sleep 5
-                if [ $(($(date +%s) - $START_TIME)) -gt $TEMPEST_IMAGE_CREATE_TIMEOUT ]; then
-                    echo "Error: Image creation exceeded the timeout period of $TEMPEST_IMAGE_CREATE_TIMEOUT seconds."
+                if [ $(($(date +%s) - $START_TIME)) -gt ${TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT[image_index]} ]; then
+                    echo "Error: Image creation exceeded the timeout period of ${TEMPEST_EXTRA_IMAGES_CREATE_TIMEOUT[image_index]} seconds."
                     exit 1
                 fi
                 STATUS=$(get_image_status)


### PR DESCRIPTION
This patch allows to modify IMAGES_CREATION_TIMEOUT for individual images. This better fits the interface of the extraImges parameter in the Tempest CR [1].

[1] https://github.com/openstack-k8s-operators/test-operator/pull/166
