### PR TITLE
List installed tempest rpms for debugging

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -336,6 +336,9 @@ function run_rpm_tempest {
     # Install additional plugins from .rpms plus their dependencies
     [ ${#TEMPEST_EXTRA_RPMS[@]} -ne 0 ] && sudo dnf install -y ${TEMPEST_EXTRA_RPMS[@]}
 
+    # List Tempest packages
+    rpm -qa | grep tempest
+
     discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
     && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?


### PR DESCRIPTION
Currently users have no idea what tempest packages are installed in the tempest containers. Printing tempest rpms will help the users to know about the same. It will be helpful for debugging in the ci logs.