### PR TITLE
Add tempest-all-downstream container image

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-all-downstream/README.md
+++ b/container-images/tcib/base/os/tempest/tempest-all-downstream/README.md
@@ -1,0 +1,5 @@
+# tempest-all-downstream container image
+
+In Downstream, openstack-tempest-all package does not ship python3-whitebox-tests-tempest.
+tempest-all-downstream container image provides a place to include all the tempest plugin which are not shipped to customers
+but used for downstream testing.

--- a/container-images/tcib/base/os/tempest/tempest-all-downstream/tempest-all-downstream.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all-downstream/tempest-all-downstream.yaml
@@ -1,0 +1,27 @@
+tcib_envs:
+  USE_EXTERNAL_FILES: true
+  TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH: /usr/libexec/octavia-tempest-plugin-tests-httpd
+tcib_actions:
+- run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/tempest_sudoers /etc/sudoers.d/tempest_sudoers
+- run: chmod 440 /etc/sudoers.d/tempest_sudoers
+- run: mkdir -p /var/lib/tempest/external_files
+- run: mkdir -p /var/lib/kolla/config_files
+- run: chown -R tempest.tempest /var/lib/tempest
+- run: touch /var/lib/kolla/config_files/config.json
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /var/lib/tempest/run_tempest.sh
+- run: chmod +x /var/lib/tempest/run_tempest.sh
+
+tcib_entrypoint: /var/lib/tempest/run_tempest.sh
+
+tcib_packages:
+  common:
+  - iputils
+  - openstack-tempest-all
+  - python3-whitebox-tests-tempest
+  - subunit-filters
+  - python3-subunit
+  - qemu-img
+
+tcib_user: tempest


### PR DESCRIPTION
In Downstream, openstack-tempest-all package does not ship python3-whitebox-tests-tempest. tempest-all-downstream container image provides a place to include all the tempest plugin which are not shipped to customers but used for downstream testing.