### PR TITLE
[tempest] Handle quotes in TEMPESTCONF_OVERRIDES

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -318,7 +318,7 @@ function run_git_tempest {
     tempest init openshift
     pushd $TEMPEST_DIR
 
-    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    eval discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
     && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 
@@ -340,7 +340,7 @@ function run_rpm_tempest {
     # List Tempest packages
     rpm -qa | grep tempest
 
-    discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    eval discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
     && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 


### PR DESCRIPTION
Use 'eval' to expand the TEMPESTCONF_OVERRIDES variable prior to using it to run discover-tempest-config. This prevents embedded quotes within the variable from being mangled.

Without the 'eval' embedded quoted strings like "Some String" get mangled into '"Some' 'String"' on the resulting command line.

Jira: [OSPRH-10092](https://issues.redhat.com//browse/OSPRH-10092)