### PR TITLE
[tempest] Fix special chars in TEMPESTCONF_OVERRIDES

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -288,6 +288,16 @@ function upload_extra_images {
     done
 }
 
+
+# This function ensures all arguments are handled properly:
+# - Embedded quotes are preserved, e.g. "Some string"
+# - Special bash characters don't need to be escaped, e.g. cubswin:)
+function discover_tempest_config {
+    cat <<EOF | xargs discover-tempest-config
+$*
+EOF
+}
+
 function run_git_tempest {
     mkdir -p $TEMPEST_EXTERNAL_PLUGIN_DIR
     pushd $TEMPEST_EXTERNAL_PLUGIN_DIR
@@ -318,7 +328,7 @@ function run_git_tempest {
     tempest init openshift
     pushd $TEMPEST_DIR
 
-    eval discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    discover_tempest_config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
     && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 
@@ -340,7 +350,7 @@ function run_rpm_tempest {
     # List Tempest packages
     rpm -qa | grep tempest
 
-    eval discover-tempest-config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
+    discover_tempest_config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
     && tempest run ${TEMPEST_ARGS}
     RETURN_VALUE=$?
 


### PR DESCRIPTION
Fix a regression introduced in PR #210 in which strings with special bash characters need to be escaped: cubswin:) has to be `cubswin:\)`. The need to escape some characters breaks existing CI jobs.

This patch fixes the regression so it's not necessary to escape special characters.