### PR TITLE
Add cpio package to ironic-conductor image

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -2,22 +2,13 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 tcib_packages:
   common:
-  - xorriso
-  - dosfstools
   - e2fsprogs
   - gdisk
-  - ipmitool
   - openssh-clients
   - openstack-ironic-conductor
   - parted
   - psmisc
-  - python3-dracclient
-  - python3-proliantutils
-  - python3-scciclient
-  - python3-sushy
   - python3-systemd
-  - qemu-img
-  - syslinux-nonlinux
   - util-linux
   - xfsprogs
 tcib_user: ironic

--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -2,6 +2,7 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 tcib_packages:
   common:
+  - cpio
   - e2fsprogs
   - gdisk
   - openssh-clients


### PR DESCRIPTION
This will allow an init container to change the contents of the ironic-python-agent ramdisk, specifically adding CA bundles.

This also removes packages which are already in the Requires for the openstack-ironic-conductor package.

Jira: [OSPRH-4541](https://issues.redhat.com//browse/OSPRH-4541)