### PR TITLE
Add socat for iscsid

### DIFF
--- a/container-images/tcib/base/os/iscsid/iscsid.yaml
+++ b/container-images/tcib/base/os/iscsid/iscsid.yaml
@@ -8,3 +8,4 @@ tcib_packages:
   - iscsi-initiator-utils
   - python3-rtslib
   - targetcli
+  - socat


### PR DESCRIPTION
We need socat to be able to run health check for the container.

Related: [OBSDA-574](https://issues.redhat.com/browse/OBSDA-574)
Related: [OSPRH-1052](https://issues.redhat.com/browse/OSPRH-1052)
Closes: [OSPRH-4118](https://issues.redhat.com/browse/OSPRH-4118)