### PR TITLE
[Tempest] Remove all images from logs

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -416,8 +416,8 @@ function generate_test_results {
     && (subunit2junitxml ${TEMPEST_LOGS_DIR}testrepository.subunit > ${TEMPEST_LOGS_DIR}tempest_results.xml || true) \
     && subunit2html ${TEMPEST_LOGS_DIR}testrepository.subunit ${TEMPEST_LOGS_DIR}stestr_results.html || true
 
-    # NOTE: Remove cirros image before copying of the logs.
-    rm ${TEMPEST_DIR}/etc/*.img
+    # NOTE: Remove images before copying of the logs.
+    rm ${TEMPEST_DIR}/etc/*.{img,qcow2}
 
     echo Copying logs file
     cp -rf ${TEMPEST_DIR}/* ${TEMPEST_LOGS_DIR}


### PR DESCRIPTION
In addtion to deleting the files with img extension [0] from the logs folder, delete also qcow2 files.

[0] https://github.com/openstack-k8s-operators/tcib/pull/197