### PR TITLE
Add dosfstools, mtools to ironic-pxe

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
@@ -12,3 +12,5 @@ tcib_packages:
   - grub2-efi-x64
   - shim
   - iproute
+  - dosfstools
+  - mtools


### PR DESCRIPTION
This is required to refactor the init scripts to accomodate IPA inject CA work. Currently this is done with an ironic-conductor image but it needs to switch to ironic-pxe, and actually this is a more appropriate image to build the ESP image with.

Jira: [OSPRH-4541](https://issues.redhat.com//browse/OSPRH-4541)