### PR TITLE
Remove dracclient from ironic-conductor image

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-conductor/ironic-conductor.yaml
@@ -12,7 +12,6 @@ tcib_packages:
   - openstack-ironic-conductor
   - parted
   - psmisc
-  - python3-dracclient
   - python3-proliantutils
   - python3-scciclient
   - python3-sushy


### PR DESCRIPTION
This was removed from ironic a few months ago[1]. We shouldn't install it in container images.

Jira: OSPCIX-545

[1] https://review.opendev.org/c/openstack/ironic/+/922340