### PR TITLE
Add inotify-tools to ironic-inspector image

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-inspector/ironic-inspector.yaml
@@ -8,4 +8,5 @@ tcib_packages:
   - openstack-ironic-inspector
   - openstack-ironic-inspector-dnsmasq
   - iproute
+  - inotify-tools
 tcib_user: ironic-inspector


### PR DESCRIPTION
Both ironic-conductor and ironic-inspector have sidecars which cat the ramdisk logs, and these are being converted to use inotifywait.

The conductor image already has the inotify-tools package, this commit adds it to the ironic-inspector image too.

Jira: [OSPRH-10240](https://issues.redhat.com//browse/OSPRH-10240)