### PR TITLE
Install tobiko project in the tobiko tcib image

### DIFF
--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -14,6 +14,7 @@ tcib_actions:
     https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
     | tar -zxvf - -C /usr/local/bin/
 - run: 'git clone https://opendev.org/x/tobiko /var/lib/tobiko/tobiko'
+- run: 'pip install -e /var/lib/tobiko/tobiko -c /var/lib/tobiko/tobiko/upper-constraints.txt -r /var/lib/tobiko/tobiko/extra-requirements.txt'
 - run: >-
     mkdir -p /var/lib/tobiko/.downloaded-images && curl
     https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img


### PR DESCRIPTION
With [1] there is CLI tool introduced in Tobiko. It can be used e.g. to run "tobiko ping" command. To be able to run such CLI command from the openstack-tobiko tcib image, Tobiko needs to be installed there, not only cloned.

[1] https://review.opendev.org/c/x/tobiko/+/935666

Related: #TOBIKO-100