### PR TITLE
[Test-Operator] Move entrypoint scripts

### DIFF
--- a/container-images/tcib/base/ansible-tests/ansibleTests.yaml
+++ b/container-images/tcib/base/ansible-tests/ansibleTests.yaml
@@ -4,11 +4,11 @@ tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: pip3 install ansible==2.9.27 openstacksdk
-- run: cp /usr/share/tcib/container-images/tcib/base/ansible-tests/run_ansible.sh /var/lib/ansible/run_ansible.sh
-- run: chmod +x /var/lib/ansible/run_ansible.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/ansible-tests/run_ansible.sh /usr/local/bin/run_ansible.sh
+- run: chmod +x /usr/local/bin/run_ansible.sh
 - run: chown -R ansible:ansible /var/lib/ansible
 
-tcib_entrypoint: /var/lib/ansible/run_ansible.sh
+tcib_entrypoint: /usr/local/bin/run_ansible.sh
 
 tcib_packages:
   common:

--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -13,11 +13,11 @@ tcib_actions:
     curl -s -L
     https://github.com/mozilla/geckodriver/releases/download/v0.29.0/geckodriver-v0.29.0-linux64.tar.gz
     | tar -zxvf - -C /usr/local/bin/
-- run: curl -OL http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img -o /var/lib/horizontest/cirros-0.6.2-x86_64-disk
-- run: cp /usr/share/tcib/container-images/tcib/base/os/horizontest/run_horizontest.sh /var/lib/horizontest/run_horizontest.sh
-- run: chmod +x /var/lib/horizontest/run_horizontest.sh
+- run: curl -OL http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img -o /usr/local/share/cirros-0.6.2-x86_64-disk
+- run: cp /usr/share/tcib/container-images/tcib/base/os/horizontest/run_horizontest.sh /usr/local/bin/run_horizontest.sh
+- run: chmod +x /usr/local/bin/run_horizontest.sh
 
-tcib_entrypoint: /var/lib/horizontest/run_horizontest.sh
+tcib_entrypoint: /usr/local/bin/run_horizontest.sh
 
 tcib_packages:
   common:

--- a/container-images/tcib/base/os/horizontest/run_horizontest.sh
+++ b/container-images/tcib/base/os/horizontest/run_horizontest.sh
@@ -4,9 +4,6 @@ set -x
 
 HORIZONTEST_DIR=/var/lib/horizontest
 HORIZON_LOGS_DIR_NAME=${HORIZON_LOGS_DIR_NAME:-"horizon"}
-IMAGE_FILE="/var/lib/horizontest/cirros-0.6.2-x86_64-disk.img"
-IMAGE_FILE_NAME=cirros-0.6.2-x86_64-disk
-IMAGE_FILE_NAME_WITH_SIZE="cirros-0.6.2-x86_64-disk (20.4 MB)"
 IMAGE_URL=http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
 PROJECT_NAME=horizontest
 USER_NAME=horizontest
@@ -17,6 +14,12 @@ SELENIUM_EXPLICIT_WAIT=180
 SELENIUM_PAGE_TIMEOUT=120
 SELENIUM_IMPLICIT_WAIT=30
 HORIZONTEST_DEBUG_MODE="${HORIZONTEST_DEBUG_MODE:-false}"
+IMAGE_FILE_NAME=cirros-0.6.2-x86_64-disk
+IMAGE_FILE_NAME_WITH_SIZE="cirros-0.6.2-x86_64-disk (20.4 MB)"
+IMAGE_FILE="/usr/local/share/${IMAGE_FILE_NAME}"
+if [[ ! -f "${IMAGE_FILE}" ]]; then
+    IMAGE_FILE="/var/lib/horizontest/${IMAGE_FILE_NAME}"
+fi
 
 # assert mandatory variables have been set
 [[ -z ${ADMIN_USERNAME} ]] && echo "ADMIN_USERNAME not set" && exit 1

--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -11,10 +11,10 @@ tcib_actions:
 - run: mkdir -p /var/lib/kolla/config_files
 - run: chown -R tempest.tempest /var/lib/tempest
 - run: touch /var/lib/kolla/config_files/config.json
-- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /var/lib/tempest/run_tempest.sh
-- run: chmod +x /var/lib/tempest/run_tempest.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /usr/local/bin/run_tempest.sh
+- run: chmod +x /usr/local/bin/run_tempest.sh
 
-tcib_entrypoint: /var/lib/tempest/run_tempest.sh
+tcib_entrypoint: /usr/local/bin/run_tempest.sh
 
 tcib_packages:
   common:

--- a/container-images/tcib/base/os/tempest/tempest.yaml
+++ b/container-images/tcib/base/os/tempest/tempest.yaml
@@ -9,10 +9,10 @@ tcib_actions:
 - run: mkdir -p /var/lib/kolla/config_files
 - run: chown -R tempest.tempest /var/lib/tempest
 - run: touch /var/lib/kolla/config_files/config.json
-- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /var/lib/tempest/run_tempest.sh
-- run: chmod +x /var/lib/tempest/run_tempest.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/run_tempest.sh /usr/local/bin/run_tempest.sh
+- run: chmod +x /usr/local/bin/run_tempest.sh
 
-tcib_entrypoint: /var/lib/tempest/run_tempest.sh
+tcib_entrypoint: /usr/local/bin/run_tempest.sh
 
 tcib_packages:
   common:

--- a/container-images/tcib/base/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/tobiko/run_tobiko.sh
@@ -3,6 +3,7 @@
 set -x
 
 TOBIKO_DIR=/var/lib/tobiko
+TOBIKO_SRC_DIR=/usr/local/src/tobiko
 TOBIKO_DEBUG_MODE="${TOBIKO_DEBUG_MODE:-false}"
 
 function catch_error_if_debug {
@@ -34,6 +35,7 @@ TOBIKO_LOGS_DIR_NAME=${TOBIKO_LOGS_DIR_NAME:-"tobiko"}
 [ ! -z ${TOBIKO_NUM_PROCESSES} ] && export TOX_NUM_PROCESSES=${TOBIKO_NUM_PROCESSES}
 
 pushd ${TOBIKO_DIR}
+cp -r ${TOBIKO_SRC_DIR} tobiko
 chown tobiko:tobiko -R tobiko
 pushd tobiko
 [ ! -z ${TOBIKO_UPDATE_REPO} ] && git pull --rebase

--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -13,19 +13,19 @@ tcib_actions:
     curl -s -L
     https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
     | tar -zxvf - -C /usr/local/bin/
-- run: 'git clone https://opendev.org/x/tobiko /var/lib/tobiko/tobiko'
-- run: 'pip install -e /var/lib/tobiko/tobiko -c /var/lib/tobiko/tobiko/upper-constraints.txt -r /var/lib/tobiko/tobiko/extra-requirements.txt'
+- run: 'git clone https://opendev.org/x/tobiko /usr/local/src/tobiko'
+- run: 'pip install -e /usr/local/src/tobiko -c /usr/local/src/tobiko/upper-constraints.txt -r /usr/local/src/tobiko/extra-requirements.txt'
 - run: >-
-    mkdir -p /var/lib/tobiko/.downloaded-images && curl
+    curl
     https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
-    -o /var/lib/tobiko/.downloaded-images/ubuntu-minimal
+    -o /usr/local/share/ubuntu-minimal
 - run: python3 -m pip install --upgrade pip
 - run: python3 -m pip install 'tox==4.13'
-- run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /var/lib/tobiko/run_tobiko.sh
-- run: chmod +x /var/lib/tobiko/run_tobiko.sh
+- run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /usr/local/bin/run_tobiko.sh
+- run: chmod +x /usr/local/bin/run_tobiko.sh
 - run: chown -R tobiko.tobiko /var/lib/tobiko
 
-tcib_entrypoint: /var/lib/tobiko/run_tobiko.sh
+tcib_entrypoint: /usr/local/bin/run_tobiko.sh
 
 tcib_packages:
   common:


### PR DESCRIPTION
We want to be able to run test pods spawned by the test-operator with
readOnlyRootFileSystem. This requires mounting of ephemeral storage to
`/var/lib/X` [1]. In this repository all write actions can be performed
(e.g., installation of additional plugins for tempest).

Mounting of the ephemeral storage causes removal of the `run_X.sh` [1]
script and other data that are stored in the `/var/lib/X` directory during
the container build (e.g., tobiko source code directory).  Therefore, we
need to move it to a different location. This patch moves:

-  all the entrypoint scripts for test operator related images
   under `/usr/local/bin`.

-  all source code downloaded during the build of a container to
   `/usr/local/src`

-  all images downloaded during the build of a container to
   `/usr/local/share`

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2579


[1] X = [tempest|tobiko|ansibletest|horizontest]