### PR TITLE
Remove ubuntu guest image from tobiko

### DIFF
--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -1,5 +1,6 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
+  TOBIKO_UPDATE_REPO: true
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
@@ -15,10 +16,6 @@ tcib_actions:
     | tar -zxvf - -C /usr/local/bin/
 - run: 'git clone https://opendev.org/x/tobiko /usr/local/src/tobiko'
 - run: 'pip install -e /usr/local/src/tobiko -c /usr/local/src/tobiko/upper-constraints.txt -r /usr/local/src/tobiko/extra-requirements.txt'
-- run: >-
-    curl
-    https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
-    -o /usr/local/share/ubuntu-minimal
 - run: python3 -m pip install --upgrade pip
 - run: python3 -m pip install 'tox==4.13'
 - run: cp /usr/share/tcib/container-images/tcib/base/tobiko/run_tobiko.sh /usr/local/bin/run_tobiko.sh
@@ -34,11 +31,11 @@ tcib_packages:
   - python3
   - python3-devel
   - python3-pip
+  - python3-setuptools
   - which
   - findutils
   - iproute
   - iputils
-  - guestfs-tools
   - iperf3
   - tcpdump
   - podman

--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -20,17 +20,41 @@
       - OWNERS*
     vars: &edpm_vars
       cifmw_run_test_role: test_operator
-      cifmw_run_tempest: true
+      cifmw_test_operator_stages:
+        - name: tempest
+          type: tempest
+        - name: tobiko
+          type: tobiko
       cifmw_test_operator_tempest_registry: "{{ content_provider_os_registry_url | split('/') | first }}"
       cifmw_test_operator_tempest_namespace: "{{ content_provider_os_registry_url | split('/') | last }}"
       cifmw_test_operator_tempest_image_tag: "{{ content_provider_dlrn_md5_hash }}"
       cifmw_test_operator_tempest_include_list: |
         tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
-      cifmw_run_tobiko: true
       cifmw_test_operator_tobiko_registry: "{{ cifmw_test_operator_tempest_registry }}"
       cifmw_test_operator_tobiko_namespace: "{{ cifmw_test_operator_tempest_namespace }}"
       cifmw_test_operator_tobiko_image_tag: "{{ content_provider_dlrn_md5_hash }}"
-      cifmw_test_operator_tobiko_testenv: "sanity"
+      cifmw_test_operator_tobiko_workflow:
+        - stepName: sanity
+          testenv: sanity
+        - stepName: scenario-nova
+          testenv: nova
+      # enabling heat is needed for some tobiko tests
+      cifmw_edpm_prepare_kustomizations:
+        - apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: openstack
+          patches:
+          - patch: |-
+              apiVersion: core.openstack.org/v1beta1
+              kind: OpenStackControlPlane
+              metadata:
+                name: unused
+              spec:
+                heat:
+                  enabled: true
+            target:
+              kind: OpenStackControlPlane
+
 
 - job:
     name: tcib-crc-podified-edpm-baremetal


### PR DESCRIPTION
With recent changes in tobiko 0.8.4, the tobiko pods will download an already customized image instead of using official ubuntu images that were customized during tobiko execution.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2619