### PR TITLE
Add httpd fix to watcher api containerfile

### DIFF
--- a/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
@@ -1,6 +1,7 @@
 tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
+- run: bash /usr/local/bin/kolla_httpd_setup
 tcib_packages:
   common:
   - openstack-watcher-api


### PR DESCRIPTION
When trying to run a Watcher API container built with the existing
container file, the httpd server fails with the error
"SSLCertificateFile: file '/etc/pki/tls/certs/localhost.crt'
does not exist or is empty". We already have an script to fix it [1],
but it's not used for the watcher api image, this change adds it.

[1] https://github.com/openstack-k8s-operators/tcib/blob/main/container-images/kolla/base/httpd_setup.sh
