### PR TITLE
Enable watcher for downstream

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -1,9 +1,6 @@
 tcib_actions:
 - run: rm -rf /home/cloud-admin && bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-# Note(chandankumar): Remove it once python3-watcherclient is available downstream
-- run: >-
-    if [ '{{ tcib_distro }}' == 'centos' ];then dnf -y install python3-watcherclient && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: openstack complete | tee /etc/bash_completion.d/osc.bash_completion > /dev/null
 - run: baremetal complete | tee /etc/bash_completion.d/baremetal.bash_completion > /dev/null
 # ensure "oc rsh" uses bash by default
@@ -23,6 +20,7 @@ tcib_packages:
   - python3-observabilityclient
   - python3-octaviaclient
   - python3-aodhclient
+  - python3-watcherclient
   - bash-completion
   - iputils
   - ipmitool

--- a/container-images/tcib/base/os/horizon/horizon.yaml
+++ b/container-images/tcib/base/os/horizon/horizon.yaml
@@ -5,9 +5,6 @@ tcib_actions:
     mv /tmp/macros.image-language-conf /etc/rpm &&
     dnf -y install {{ tcib_packages.common | join(' ') }} &&
     dnf clean all && rm -rf /var/cache/dnf
-# Note(chandankumar): Remove it once openstack-watcher-ui package is available downstream.
-- run: >-
-    if [ '{{ tcib_distro }}' == 'centos' ];then dnf -y install openstack-watcher-ui && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: cp /usr/share/tcib/container-images/kolla/horizon/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
 - run: >-
@@ -36,3 +33,4 @@ tcib_packages:
   - openstack-manila-ui
   - openstack-octavia-ui
   - openstack-designate-ui
+  - openstack-watcher-ui


### PR DESCRIPTION
Watcher related packages are available downstream. This pr removes the centos conditional for the same.

Realted-Jira: https://issues.redhat.com/browse/OSPRH-12829