### PR TITLE
Backport: Build OpenStack Watcher Container

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -77,3 +77,6 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-tempest-extras:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-tobiko:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-openstackclient:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-watcher-api:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-watcher-applier:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-watcher-decision-engine:current-podified

--- a/container-images/kolla/base/uid_gid_manage.sh
+++ b/container-images/kolla/base/uid_gid_manage.sh
@@ -71,6 +71,7 @@ _SUPPORTED_USERS['tempest']='tempest 42480 42480 /var/lib/tempest kolla'
 _SUPPORTED_USERS['tobiko']='tobiko 42495 42495 /var/lib/tobiko kolla'
 _SUPPORTED_USERS['tss']='tss 59 59'
 _SUPPORTED_USERS['ansible']='ansible 227 227 /var/lib/ansible kolla'
+_SUPPORTED_USERS['watcher']='watcher 42451 42451 /var/lib/watcher kolla'
 
 for _USER_TO_CREATE in $_USERS_TO_CREATE; do
     # Initialize computed args

--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -1,6 +1,9 @@
 tcib_actions:
 - run: rm -rf /home/cloud-admin && bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+# Note(chandankumar): Remove it once python3-watcherclient is available downstream
+- run: >-
+    if [ '{{ tcib_distro }}' == 'centos' ];then dnf -y install python3-watcherclient && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: openstack complete | tee /etc/bash_completion.d/osc.bash_completion > /dev/null
 - run: baremetal complete | tee /etc/bash_completion.d/baremetal.bash_completion > /dev/null
 # ensure "oc rsh" uses bash by default

--- a/container-images/tcib/base/os/horizon/horizon.yaml
+++ b/container-images/tcib/base/os/horizon/horizon.yaml
@@ -5,6 +5,9 @@ tcib_actions:
     mv /tmp/macros.image-language-conf /etc/rpm &&
     dnf -y install {{ tcib_packages.common | join(' ') }} &&
     dnf clean all && rm -rf /var/cache/dnf
+# Note(chandankumar): Remove it once openstack-watcher-ui package is available downstream.
+- run: >-
+    if [ '{{ tcib_distro }}' == 'centos' ];then dnf -y install openstack-watcher-ui && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: cp /usr/share/tcib/container-images/kolla/horizon/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
 - run: >-

--- a/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
@@ -1,0 +1,10 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
+tcib_packages:
+  common:
+  - openstack-watcher-api
+  - httpd
+  - mod_ssl
+  - python3-mod_wsgi
+tcib_user: watcher

--- a/container-images/tcib/base/os/watcher-base/watcher-applier/watcher-applier.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-applier/watcher-applier.yaml
@@ -1,0 +1,6 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+tcib_packages:
+  common:
+  - openstack-watcher-applier
+tcib_user: watcher

--- a/container-images/tcib/base/os/watcher-base/watcher-base.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-base.yaml
@@ -1,0 +1,6 @@
+tcib_actions:
+- run: bash /usr/local/bin/uid_gid_manage watcher
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+tcib_packages:
+  common:
+  - openstack-watcher-common

--- a/container-images/tcib/base/os/watcher-base/watcher-decision-engine/watcher-decision-engine.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-decision-engine/watcher-decision-engine.yaml
@@ -1,0 +1,6 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+tcib_packages:
+  common:
+  - openstack-watcher-decision-engine
+tcib_user: watcher


### PR DESCRIPTION
This pull request:
* Builds OpenStack Watcher containers
* Add python-watcherclient package to openstackclient container
* Add openstack-watcher-ui package to horizon container

Note: python-watcherclient and openstack-watcher-ui is not available in downstream currently. It is available in CentOS Stream with RDO antelope release. That's why we have added these packages under tcib_distro conditional to avoid breakage downstream.

Jira: https://issues.redhat.com/browse/OSPRH-11085