### PR TITLE
Revert "Add httpd fix to watcher api containerfile"

### DIFF
--- a/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
+++ b/container-images/tcib/base/os/watcher-base/watcher-api/watcher-api.yaml
@@ -1,7 +1,6 @@
 tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
-- run: bash /usr/local/bin/kolla_httpd_setup
 tcib_packages:
   common:
   - openstack-watcher-api


### PR DESCRIPTION
This is not longer needed after [1].

[1] https://github.com/openstack-k8s-operators/watcher-operator/pull/53

This reverts commit 1ea72804b249cf25ada5c63bcdb5ab8326ee677a.