### PR TITLE
[18.0-fr1]Drop tobiko tests from the jobs

### DIFF
--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -27,11 +27,6 @@
       cifmw_test_operator_tempest_image_tag: "{{ content_provider_dlrn_md5_hash }}"
       cifmw_test_operator_tempest_include_list: |
         tempest.scenario.test_network_basic_ops.TestNetworkBasicOps
-      cifmw_run_tobiko: true
-      cifmw_test_operator_tobiko_registry: "{{ cifmw_test_operator_tempest_registry }}"
-      cifmw_test_operator_tobiko_namespace: "{{ cifmw_test_operator_tempest_namespace }}"
-      cifmw_test_operator_tobiko_image_tag: "{{ content_provider_dlrn_md5_hash }}"
-      cifmw_test_operator_tobiko_testenv: "sanity"
 
 - job:
     name: tcib-crc-podified-edpm-baremetal


### PR DESCRIPTION
The jobs are broken and we probably should not run those tests here.

cherry-picks https://github.com/openstack-k8s-operators/tcib/pull/245