### PR TITLE
Add python3-mod_wsgi to glance_api image

### DIFF
--- a/container-images/tcib/base/os/glance-api/glance-api.yaml
+++ b/container-images/tcib/base/os/glance-api/glance-api.yaml
@@ -11,6 +11,7 @@ tcib_packages:
   - iscsi-initiator-utils
   - openstack-glance
   - python3-boto3
+  - python3-mod_wsgi
   - python3-rados
   - python3-rbd
   - qemu-img


### PR DESCRIPTION
This package is required in order to run `glance_api` under `httpd`, as opposed to running its own `eventlet` based server.

Jira: https://issues.redhat.com/browse/OSPRH-14531