### PR TITLE
Allow installing not only collection

### DIFF
--- a/container-images/tcib/base/ansible-tests/run_ansible.sh
+++ b/container-images/tcib/base/ansible-tests/run_ansible.sh
@@ -35,7 +35,7 @@ fi
 
 # Install collections from requirements.yaml if the file exists
 if [[ -f "$ANSIBLE_DIR/requirements.yaml" ]]; then
-    ansible-galaxy collection install -r "$ANSIBLE_DIR/requirements.yaml"
+    ansible-galaxy install -r "$ANSIBLE_DIR/requirements.yaml"
 else
     echo "requirements.yaml doesn't exist, skipping requirements installation"
 fi


### PR DESCRIPTION
when using collection inside the ansible-galaxy command with the collection flag only collections are installed this doesn't install additional types of possible requirments like roles. removed the collection keyword from the ansible galaxy install command to allow installing roles as requirements