### PR TITLE
Add python3-networking-generic-switch to neutron-server image

### DIFF
--- a/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
+++ b/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
@@ -7,4 +7,5 @@ tcib_packages:
   - mod_ssl
   - python3-networking-baremetal
   - python3-mod_wsgi
+  - python3-networking-generic-switch
 tcib_user: neutron


### PR DESCRIPTION
This will allow neutron to be configured to use
networking-generic-switch to configure physical switches as an ML2 driver.

This can be merged on the antelope branch when [RELDEL-4625](https://issues.redhat.com//browse/RELDEL-4625) is complete.

Jira: [OSPRH-15368](https://issues.redhat.com//browse/OSPRH-15368)