### PR TITLE
Revert "Enable weak deps for tempest-all container image"

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -2,7 +2,6 @@ tcib_envs:
   USE_EXTERNAL_FILES: true
   TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH: /usr/libexec/octavia-tempest-plugin-tests-httpd
 tcib_actions:
-- run: crudini --set /etc/dnf/dnf.conf main install_weak_deps True
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/tempest_sudoers /etc/sudoers.d/tempest_sudoers


### PR DESCRIPTION
Reverts openstack-k8s-operators/tcib#203

We don't want to enable weak deps as that pulls some unnecessary
packages. And this might not work when moving to do different
container build environment, so reverting. Original tempest-distgit 
patch[1] for which original patch was pushed was also got abandoned.

[1] https://review.rdoproject.org/r/c/openstack/tempest-distgit/+/54169

Related-Issue: [OSPRH-5436](https://issues.redhat.com//browse/OSPRH-5436)
Related-Issue: [OSPRH-6334](https://issues.redhat.com//browse/OSPRH-6334)