### PR TITLE
Add CentOS Stream 10 support in tcib

### DIFF
--- a/container-images/tcib/base/os/horizon/horizon.yaml
+++ b/container-images/tcib/base/os/horizon/horizon.yaml
@@ -10,14 +10,14 @@ tcib_actions:
 - run: >-
     sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf &&
     sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf &&
-    ln -s /usr/share/openstack-dashboard/openstack_dashboard /usr/lib/python3.9/site-packages/openstack_dashboard &&
-    ln -s /usr/share/openstack-dashboard/static /usr/lib/python3.9/site-packages/static &&
+    ln -s /usr/share/openstack-dashboard/openstack_dashboard /usr/lib/python{{ tcib_python_version }}/site-packages/openstack_dashboard &&
+    ln -s /usr/share/openstack-dashboard/static /usr/lib/python{{ tcib_python_version }}/site-packages/static &&
     chown -R apache /etc/openstack-dashboard /usr/share/openstack-dashboard &&
     chown -R apache /usr/share/openstack-dashboard/static &&
     sed -i "s|WEBROOT = ''/dashboard/''|WEBROOT = ''/''|" /etc/openstack-dashboard/local_settings &&
     cp /usr/share/openstack-dashboard/manage.py /usr/bin/manage.py &&
-    rm -f /usr/share/openstack-dashboard/openstack_dashboard/local/enabled/?[^_]*.py* && rm -f /usr/lib/python3.9/site-packages/openstack_dashboard/local/enabled/?[^_]*.py* &&
-    for locale in /usr/lib/python3.9/site-packages/*/locale; do (cd ${locale%/*} && /usr/bin/django-admin compilemessages) done
+    rm -f /usr/share/openstack-dashboard/openstack_dashboard/local/enabled/?[^_]*.py* && rm -f /usr/lib/python{{ tcib_python_version }}/site-packages/openstack_dashboard/local/enabled/?[^_]*.py* &&
+    for locale in /usr/lib/python{{ tcib_python_version }}/site-packages/*/locale; do (cd ${locale%/*} && /usr/bin/django-admin compilemessages) done
 tcib_packages:
   common:
   - gettext

--- a/container-images/tcib/base/os/keystone/keystone.yaml
+++ b/container-images/tcib/base/os/keystone/keystone.yaml
@@ -1,6 +1,8 @@
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage keystone
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: >-
+    if [ '{{ tcib_release }}' == '9' ];then dnf -y install mod_auth_mellon && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: mkdir -p /var/www/cgi-bin/keystone && chown -R keystone /var/www/cgi-bin/keystone
 - run: cp /usr/share/tcib/container-images/kolla/keystone/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
@@ -12,7 +14,6 @@ tcib_packages:
   common:
   - httpd
   - mod_auth_gssapi
-  - mod_auth_mellon
   - mod_auth_openidc
   - mod_ssl
   - openstack-keystone

--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -38,5 +38,5 @@ tcib_packages:
   - iperf3
   - tcpdump
   - podman
-
+  - libffi-devel
 tcib_user: tobiko


### PR DESCRIPTION
This pr updates the container files for centos stream 10:

-  In CS10, python3.12 is the default python runtime that's why tcib_python_version is used in horizon
-  mod_auth_mellon is dropped from CS10, that's why it is default to cs9 only.
-    tobiko container needs libffi-devel package to be there.

Tested here: https://softwarefactory-project.io/zuul/t/rdoproject.org/build/3137cbfb56cd4445ad1f2805cd1c4e96 and here is the built containers: https://logserver.rdoproject.org/313/rdoproject.org/3137cbfb56cd4445ad1f2805cd1c4e96/ci-framework-data/logs/containers-built.log

Jira: [OSPRH-16308](https://issues.redhat.com//browse/OSPRH-16308)
