### PR TITLE
Update urllib version for horizontest container

### DIFF
--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -35,6 +35,6 @@ tcib_packages:
   - testtools
   - xvfbwrapper
   - junit2html
-  - urllib3==1.26.18
+  - urllib3==1.26.19
 
 tcib_user: horizontest


### PR DESCRIPTION
Update urllib3 version for it be compatible with Centos10 . With current version there is a conflict 
Resolves https://issues.redhat.com/browse/OSPRH-16481