### PR TITLE
Create symlink for /etc/pki/tls/cert.pem

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -15,6 +15,7 @@ tcib_actions:
     crudini --set /etc/dnf/dnf.conf main skip_missing_names_on_install False &&
     crudini --set /etc/dnf/dnf.conf main tsflags nodocs
 - run: dnf install -y {{ tcib_packages['common'] | join(' ') }} {{ tcib_package }}
+- run: if [ ! -f "/etc/pki/tls/cert.pem" ]; then ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/cert.pem; fi
 - run: cp /usr/share/tcib/container-images/kolla/base/uid_gid_manage.sh /usr/local/bin/uid_gid_manage
 - run: chmod 755 /usr/local/bin/uid_gid_manage
 - run: bash /usr/local/bin/uid_gid_manage kolla hugetlbfs libvirt qemu


### PR DESCRIPTION
In CentOS Stream 10, ca-certificates-2024.2.69_v8.0.303-102.3.el10.noarch package provides /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem file but it does not provides /etc/pki/tls/cert.pem.

In order to cert work properly in EDPM job, we need /etc/pki/tls/cert.pem file otherwise we will see ssl errors.

This pr creates symlink for the same.

Jira: [OSPRH-16670](https://issues.redhat.com//browse/OSPRH-16670)