### PR TITLE
Replace mod_wsgi with uwsgi for designateapi

### DIFF
--- a/container-images/tcib/base/os/designate-base/designate-api/designate-api.yaml
+++ b/container-images/tcib/base/os/designate-base/designate-api/designate-api.yaml
@@ -6,4 +6,5 @@ tcib_packages:
   - httpd
   - mod_ssl
   - python3-mod_wsgi
+  - uwsgi
 tcib_user: designate


### PR DESCRIPTION
mod_wsgi is being removed from upstream sources but OpenStack APIs are still using it downstream, which is very concerning.

This patch replaces mod_wsgi with uwsgi.