### PR TITLE
Drop centos repos if exists

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -1,5 +1,6 @@
 tcib_actions:
 - run: if [ -f "/etc/yum.repos.d/ubi.repo" ]; then rm -f /etc/yum.repos.d/ubi.repo && dnf clean all && rm -rf /var/cache/dnf; fi
+- run: if [ -f "/etc/yum.repos.d/centos.repo" ]; then rm -f /etc/yum.repos.d/centos*.repo && dnf clean all && rm -rf /var/cache/dnf; fi
 - run: >-
     dnf install -y crudini &&
     crudini --del /etc/dnf/dnf.conf main override_install_langs &&


### PR DESCRIPTION
In tcib, we use repo-setup provided centos repos. But in centos base image, we have centos and centos-addons repos.

Currently we are hitting repo timeout while pulling content from centos repo due to repo sync issue.

In order to this issue, we are removing centos repo and rely on repo-setup provided centos repos to avoid such  issues.