### PR TITLE
Remove TOBIKO_UPDATE_REPO logic; always update Tobiko repo

### DIFF
--- a/container-images/tcib/base/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/tobiko/run_tobiko.sh
@@ -38,7 +38,7 @@ pushd ${TOBIKO_DIR}
 cp -r ${TOBIKO_SRC_DIR} tobiko
 chown tobiko:tobiko -R tobiko
 pushd tobiko
-[ ! -z ${TOBIKO_UPDATE_REPO} ] && git pull --rebase
+git pull --rebase
 git checkout ${TOBIKO_VERSION}
 
 # obtain clouds.yaml, ssh private/public keys and tobiko.conf from external_files directory

--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -1,6 +1,5 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
-  TOBIKO_UPDATE_REPO: true
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
Always updating the Tobiko repository is the preferred behavior. Removing the TOBIKO_UPDATE_REPO variable entirely would eliminate unnecessary complexity.