### PR TITLE
Set UTC timezone in tcib containers

### DIFF
--- a/container-images/tcib/base/base.yaml
+++ b/container-images/tcib/base/base.yaml
@@ -36,6 +36,7 @@ tcib_actions:
     dnf -y reinstall which &&
     rpm -e --nodeps tzdata &&
     dnf -y install tzdata
+- run: if [ ! -f "/etc/localtime" ]; then ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime; fi
 - run: mkdir -p /openstack
 - run: >-
     if [ '{{ tcib_distro }}' == 'centos' ];then
@@ -47,6 +48,7 @@ tcib_entrypoint: dumb-init --single-child --
 tcib_envs:
   LANG: en_US.UTF-8
   container: oci
+  TZ: UTC
 tcib_labels:
   maintainer: OpenStack Kubernetes Operator team
   tcib_managed: True


### PR DESCRIPTION
In the past, rhel/centos base containers had default local timezone configured to UTC.

Recently, some base RHEL container images are not providing any default timezone [1], and that's affecting some services, as watcher, which require to discover it.

This patch is setting local timezone to UTC which is the expected one for deployiments using openstack-k8s-operators. I am proposing to provide both TZ environment variable which is used for some libraries and tools [2] but also creating the /etc/localtime file which is the traditional and more extended way of locating the timezone.

[1] https://issues.redhat.com/browse/RHEL-103768
[2] https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html