### PR TITLE
Install git-core instead of git

### DIFF
--- a/container-images/tcib/base/ansible-tests/ansibleTests.yaml
+++ b/container-images/tcib/base/ansible-tests/ansibleTests.yaml
@@ -15,7 +15,7 @@ tcib_entrypoint: /usr/local/bin/run_ansible.sh
 tcib_packages:
   common:
   - gcc
-  - git
+  - git-core
   - python3
   - python3-devel
   - python3-pip

--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -21,7 +21,7 @@ tcib_entrypoint: /usr/local/bin/run_horizontest.sh
 
 tcib_packages:
   common:
-  - git
+  - git-core
   - python3-pip
   - xorg-x11-server-Xvfb
   - firefox

--- a/container-images/tcib/base/tobiko/tobiko.yaml
+++ b/container-images/tcib/base/tobiko/tobiko.yaml
@@ -26,7 +26,7 @@ tcib_entrypoint: /usr/local/bin/run_tobiko.sh
 tcib_packages:
   common:
   - gcc
-  - git
+  - git-core
   - python3
   - python3-devel
   - python3-pip


### PR DESCRIPTION
git-core is enough for our usage in these container images, "git" pulls some unnecessary perl deps.

Just noticed while looking into [OSPCIX-935](https://issues.redhat.com//browse/OSPCIX-935)