### PR TITLE
Add neutron-fwaas package to be installed in Neutron images

### DIFF
--- a/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
+++ b/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
@@ -8,4 +8,5 @@ tcib_packages:
   - python3-networking-baremetal
   - python3-mod_wsgi
   - python3-networking-generic-switch
+  - python3-neutron-fwaas
 tcib_user: neutron


### PR DESCRIPTION
This package provides Firewall-As-A-Service service plugin for Neutron. Project neutron-fwaas is in the Neutron stadium in upstream and is revived since couple of cycles. Now we are going to also include it in the RHOSO releases.

Closes: #[OSPRH-15213](https://issues.redhat.com//browse/OSPRH-15213)