### PR TITLE
Always Download tempest extra image

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -228,11 +228,12 @@ function get_image_status {
 
 function upload_extra_images {
     for image_index in "${!TEMPEST_EXTRA_IMAGES_NAME[@]}"; do
+        if [[ ! -f "${TEMPEST_EXTRA_IMAGES_NAME[image_index]}" ]]; then
+            curl -o "${HOMEDIR}/${TEMPEST_EXTRA_IMAGES_NAME[image_index]}" "${TEMPEST_EXTRA_IMAGES_URL[image_index]}"
+        fi
+
         if ! openstack image show ${TEMPEST_EXTRA_IMAGES_NAME[image_index]}; then
             image_create_params=()
-
-            [[ ! -f "${TEMPEST_EXTRA_IMAGES_NAME[image_index]}" ]] && \
-                curl -o "${HOMEDIR}/${TEMPEST_EXTRA_IMAGES_NAME[image_index]}" "${TEMPEST_EXTRA_IMAGES_URL[image_index]}"
 
             [[ ${TEMPEST_EXTRA_IMAGES_DISK_FORMAT[image_index]} != "-" ]] && \
                 image_create_params+=(--disk-format ${TEMPEST_EXTRA_IMAGES_DISK_FORMAT[image_index]})


### PR DESCRIPTION
Tempest requires a few of the images configured to bot server/volume.
It expects some of the images (image_ref, image_ref_alt) to be present
in glance and tests use glance image id. But in some tests it requires
images to be present in the configured locations. for example:

1. conf.scenario.img_file: https://github.com/openstack/tempest/blob/33c1959cdbedf33a93cce
   >  - sample_conf for image_file ref: https://docs.openstack.org/tempest/latest/sampleconf.html

In this case, Tempest scenario manager will require the image file to
be present in the configured location and it upload the same to glance.
If it does not find the image in that location (even it is present in glance)
 then it fails:
- https://github.com/openstack/tempest/blob/33c1959cdbedf33a93cce470659f54d2a3f4a160/tempest

2. New test to boot from iso image: conf.whitebox.http_iso_image
- https://github.com/openstack/whitebox-tempest-plugin/blob/19f39aba511ddf6ecddd0e7dd5ae24
- patch: https://review.opendev.org/c/openstack/whitebox-tempest-plugin/+/955950

In this case, test need iso image to be present in the configured location
and if it does not exist then test fail (even image is present in glance)
- https://github.com/openstack/whitebox-tempest-plugin/blob/19f39aba511ddf6ecddd0e7dd5ae24

These above images are configured in TEMPEST_EXTRA_IMAGES_NAME. To solve the
cases, irrespective of tempest extra image is present in glance, we still
need images to be present in the configured location.

Testing:

The 2nd case is tested in:
- https://gitlab.cee.redhat.com/ci-framework/ci-framework-testproject/-/merge_requests/1464
Test passing fine
- [https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/>](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/543c2322d63e4dc0a1c8acf080772d89/log/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/pods/tempest-tests-tempest-s00-whitebox/logs/tempest-tests-tempest-tests-runner.log#1523)