### PR TITLE
Revert "Add neutron-fwaas package to be installed in Neutron-server i…

### DIFF
--- a/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
+++ b/container-images/tcib/base/os/neutron-base/neutron-server/neutron-server.yaml
@@ -8,5 +8,4 @@ tcib_packages:
   - python3-networking-baremetal
   - python3-mod_wsgi
   - python3-networking-generic-switch
-  - python3-neutron-fwaas
 tcib_user: neutron


### PR DESCRIPTION
…mage"

This reverts commit d1e8ded739414ab8e106724ff388727dd6cf99be.

Reason: Unfortunatelly we don't have neutron-fwaas rpm package build from master branch on CentOS 9 stream and we won't have such because neutron-fwaas u/s dropped support for python < 3.10 recently and in CentOS 9 stream python 3.9 is available.

This revert is temporary to unblock TCIB job
periodic-container-tcib-build-push-centos-9-master before it will be migrated to CentOS 10.

Closes: #[OSPCIX-1015](https://issues.redhat.com//browse/OSPCIX-1015)