### PR TITLE
Fix issue TEMPEST_EXPECTED_FAILURES_LIST is empty

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -499,10 +499,10 @@ if [ ${TEMPEST_DEBUG_MODE} == true ]; then
     sleep infinity
 fi
 
-if [ -s ${TEMPEST_LOGS_DIR}stestr_failing.txt ] && [ -s ${TEMPEST_EXPECTED_FAILURES_LIST} ]; then
+if [ -n "${TEMPEST_EXPECTED_FAILURES_LIST}" ] && [ -s ${TEMPEST_LOGS_DIR}stestr_failing.txt ] && [ -s "${TEMPEST_EXPECTED_FAILURES_LIST}" ]; then
     echo "Failing tests marked as expected failures"
-    grep -Fxf ${TEMPEST_EXPECTED_FAILURES_LIST} ${TEMPEST_LOGS_DIR}stestr_failing.txt
-    if ! grep -Fxv -q -f ${TEMPEST_EXPECTED_FAILURES_LIST} ${TEMPEST_LOGS_DIR}stestr_failing.txt ; then
+    grep -Fxf "${TEMPEST_EXPECTED_FAILURES_LIST}" ${TEMPEST_LOGS_DIR}stestr_failing.txt
+    if ! grep -Fxv -q -f "${TEMPEST_EXPECTED_FAILURES_LIST}" ${TEMPEST_LOGS_DIR}stestr_failing.txt ; then
         RETURN_VALUE=0
     fi
 fi


### PR DESCRIPTION
Because the condition [ -s ${var} ] would evaluate to [ -s  ], with an empty argument, the shell can behave unexpectedly, and subsequent grep commands would try to read from an empty filename.

We belive this is the reason failing tempest tests did not fail, see Jira for logs.

Add a check to ensure TEMPEST_EXPECTED_FAILURES_LIST is not empty before attempting file operations.

Also add quoting around variable references.

Fixes: OSPRH-19179