### PR TITLE
A little tiny bit of tempest rework + re-run feature implemented

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -498,7 +498,7 @@ function rerun_failed_tests {
 
     pushd $TEMPEST_DIR
 
-    tempest run ${TEMPEST_ARGS} --include-list "${FAILED_TESTS_FILE}"
+    tempest run ${TEMPEST_ARGS} --include-list <(sed -e 's#^\(setUpClass\|tearDownClass\) ##g' "${FAILED_TESTS_FILE}")
     _RETURN_VALUE=$?
 
     if [ "${RERUN_OVERRIDE_STATUS}" = true ]; then


### PR DESCRIPTION
I wanted to implement one small feature... But then I noticed the overall shape of this script... And I decided it is time time to introduce some tidiness and order in it – otherwise the feature I want to implement (re-run of tempest) would introduce even more mess to that madness.

Long story short, there are the following contributions in this pull request:

**Update shebang**

This script actually used features available in Bash,
not in basic shell – a detail, but important to cover.

**Move print of config files to function**

It was a part of `generate_test_results`
and served only the purpose of debugging
in pod logs. Moving it to dedicated function
for clarity.

**Move saving of config files to dedicated function**

The existing code was part of `generate_test_results`,
however it actually copied only empty `logs` directory
and empty `tempest_lock` directory. Moreover, in copied
`etc` directory there were useless sample files.
This commit changes it to be part of dedicated function,
for clarity, as well as adjusts to save more useful
files from the pod.

**Add function to move tempest.log**

This function will be useful to saving
the tempest.log in case of multiple runs.

**Rework generate_test_results**

Instead of using files directly in commands,
this commit introduces local variables to function
so it is easier to maintain changes in file names.

**Rename files in generate_test_results**

This commit adjusts the names of produced files
to keep the same name pattern.

**Allow custom file name in generate_test_results**

This would allow easy override of the produced report names,
which will be useful in case we want to perform multiple runs
and save results from each of the runs.

**Move WNTP workaround to dedicated function**

Just for tidiness in the script!

**Add prepare_tempest_cleanup function**

There is a big block duplicated code currently.
This commit moves that code to a separate function,
removing the redundancy and allowing easier maintenance.

**Add run_tempest_cleanup function**

This commit takes the duplicated code
and moves to a dedicated function,
allowing easier maintenance of the code.

**Add variable for stestr_failing.txt file**

That file is referred in multiple places,
so it would be convenient to use single variable
instead of always specifying the path and filename.

**Add run_tempest function**

Currently there are two ways to execute tempest
considered within the script – one from installed
RPM package and one from deployed virtual environment,
in case when there is any git plugin requested.
However, the essential calls relate to execution
are currently a duplicated code – this commit
extracts that part into a common function.

**Add variable for path to venv directory**

This commit introduces a variable to keep
the path to the virtual environment that is
created when the tempest with external git plugins
is to be used.

**Add function to re-run failed tests**

Life is life and the reality is often disappointing.
When you run over a 1000 tempest tests, you can hit
some single ones that failed due to random reason.
This commit implements a killer feature that would
re-run those tests that failed. This gives a chance
to test the fate and not mark the whole build
as a failure if the problem is a pure-random thing
that never occurs again.

**Make override of exit status optional in re-run**

This commit adds the parameter to configure
whether the re-run of failed tests should
override the exit status in case of success.
This allows checking "what would it be"
without introducing any additional risk
in the CI environments due to new behavior.

**Move expected failures check to function**

For better clarity of the main execution block in script.
Also, this commit adds the reasonable default value
for the expected failures list ~ in case it was not set
by the test-operator for some reason.

**Set default RETURN_VALUE**

This script at the end expects that value,
that may be overridden by some function calls.
The courtesy requires setting such variable
to default value at the beginning of script.