### PR TITLE
[OSPRH-19621] Add cloudkittyclient to openstackclient image

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -21,6 +21,7 @@ tcib_packages:
   - python3-octaviaclient
   - python3-aodhclient
   - python3-watcherclient
+  - python3-cloudkittyclient
   - bash-completion
   - iputils
   - ipmitool


### PR DESCRIPTION
Cloudkittyclient is needed for the oncoming chargeback feature.