### PR TITLE
Bump tox tests to python 3.12

### DIFF
--- a/.github/workflows/toxjobs.yml
+++ b/.github/workflows/toxjobs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-yaml
         files: .*\.(yaml|yml)$
   - repo: https://github.com/pycqa/flake8.git
-    rev: 3.9.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/openstack-dev/bashate.git
@@ -28,6 +28,25 @@ repos:
         #       use jinja templating, this will often fail and the syntax
         #       error will be discovered in execution anyway)
   - repo: https://github.com/PyCQA/pylint
-    rev: pylint-2.7.2
+    rev: v3.3.8
     hooks:
       - id: pylint
+        args:
+          [
+            "--disable=C0209,R0917,R1705,R1734,R1735,W1514,W3301"
+          ]
+          # C0209: Formatting a regular string which could be an
+          #        f-string (consider-using-f-string)
+          # R0917: Too many positional arguments (25/5)
+          #        (too-many-positional-arguments)
+          # R1705: Unnecessary "else" after "return", remove the "else"
+          #        and de-indent the code inside it (no-else-return)
+          # R1734: Consider using [] instead of list() (use-list-literal)
+          # R1753: Consider using '{}' instead of a call to 'dict'.
+          #        (use-dict-literal)
+          # W1514: Using open without explicitly specifying
+          #        an encoding (unspecified-encoding)
+          # W3301: Do not use nested call of 'min'; it's possible to do
+          #        'min(8, max(2, processutils.get_worker_count()),
+          #         len(containers))'
+          #         instead (nested-min-max)

--- a/tcib/client/utils.py
+++ b/tcib/client/utils.py
@@ -59,7 +59,7 @@ class TempDirs(object):
 
     def __init__(self, dir_path=None, dir_prefix='tcib', cleanup=True,
                  chdir=True):
-        """This context manager will create, push, and cleanup temp directories.
+        """This context manager will create, push and cleanup temp directories.
         >>> with TempDirs() as t:
         ...     with open('file', 'w') as f:
         ...         f.write('test')


### PR DESCRIPTION
Upstream master now supports python 3.10 to python 3.12. The
requirements can't be satisfied for 3.9 anymore, so bump the
tox workflow to 3.12.

With the higher version of python, bumps to flake8 and pylint
were needed as well. Pylint added some new checks it seems. Those
that report errors at the moment are disabled.

One line was exactly 80 character long. I shortened it to pass the
<= 79 character length check.
