### PR TITLE
Integrating stackviz with test-operator

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -481,6 +481,22 @@ function generate_test_results {
 }
 
 
+function generate_stackviz_report {
+    _SUBUNIT_FILE="${TEMPEST_LOGS_DIR}/tempest_results.subunit"
+    _STACKVIZ_DIR="${TEMPEST_LOGS_DIR}/stackviz"
+
+    if [ -f "${_SUBUNIT_FILE}" ]; then
+        echo "Generating Stackviz report..."
+        mkdir -p "${_STACKVIZ_DIR}"
+        stackviz-export "${_SUBUNIT_FILE}" "${_STACKVIZ_DIR}/data"
+        # Optionally build full HTML frontend
+        stackviz-html "${_STACKVIZ_DIR}/data" "${_STACKVIZ_DIR}/html"
+    else
+        echo "No subunit file found for Stackviz"
+    fi
+}
+
+
 function rerun_failed_tests {
     # Perform re-run of tests that failed in previous execution, if requested.
     # Saves the results in the logs directory and (if set to do so) overrides
@@ -587,6 +603,7 @@ print_config_files
 save_config_files
 move_tempest_log tempest_results.log
 generate_test_results tempest_results
+generate_stackviz_report
 
 rerun_failed_tests
 check_expected_failures

--- a/container-images/tcib/base/os/tempest/tempest.yaml
+++ b/container-images/tcib/base/os/tempest/tempest.yaml
@@ -3,6 +3,7 @@ tcib_envs:
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: pip install git+https://opendev.org/openstack/stackviz
 - run: cp /usr/share/tcib/container-images/tcib/base/os/tempest/tempest_sudoers /etc/sudoers.d/tempest_sudoers
 - run: chmod 440 /etc/sudoers.d/tempest_sudoers
 - run: mkdir -p /var/lib/tempest/external_files
@@ -20,6 +21,7 @@ tcib_packages:
   - openstack-tempest
   - subunit-filters
   - python3-subunit
+  - python3-pip
   - qemu-img
 
 tcib_user: tempest


### PR DESCRIPTION
Updated tempest.yaml to install stackviz and added a function to run_tempest.sh to generate stackviz report from the subunit file

Ticket: OSPRh-12077