### PR TITLE
[tempest] Update constraints file when installing an external plugin

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -403,7 +403,7 @@ function run_git_tempest {
             popd
         fi
 
-        pip install -chttps://releases.openstack.org/constraints/upper/2023.1 "./${plugin_name}"
+        pip install -chttps://opendev.org/openstack/requirements/raw/branch/master/upper-constraints.txt "./${plugin_name}"
     done
 
     run_tempest


### PR DESCRIPTION
For the main branch, the constraints file used when installing an external version should use a newer constraints file that 2023.1 (antelope) 
Plugins being installed when using the master container should be installed using the upper constraints for the master branch of openstack.