### PR TITLE
[ansibletest] Add a branch for the git repo

### DIFF
--- a/container-images/tcib/base/ansible-tests/run_ansible.sh
+++ b/container-images/tcib/base/ansible-tests/run_ansible.sh
@@ -7,6 +7,7 @@ ANSIBLE_FILE_EXTRA_VARS_PARAM="${ANSIBLE_FILE_EXTRA_VARS_PARAM:-}"
 POD_ANSIBLE_PLAYBOOK="${POD_ANSIBLE_PLAYBOOK:-}"
 POD_ANSIBLE_EXTRA_VARS="${POD_ANSIBLE_EXTRA_VARS:-}"
 POD_ANSIBLE_GIT_REPO="${POD_ANSIBLE_GIT_REPO:-}"
+POD_ANSIBLE_GIT_BRANCH="${POD_ANSIBLE_GIT_BRANCH:-}"
 
 # Check and set ansible debug verbosity
 ANSIBLE_DEBUG=""
@@ -16,6 +17,12 @@ fi
 
 # Clone the Ansible repository
 git clone "$POD_ANSIBLE_GIT_REPO" "$ANSIBLE_DIR"
+
+if [[ -n "$POD_ANSIBLE_GIT_BRANCH" ]]; then
+    pushd "$ANSIBLE_DIR"
+    git fetch && git checkout --track origin/${POD_ANSIBLE_GIT_BRANCH}
+    popd
+fi
 
 # Handle extra vars file if provided
 if [[ -n "${POD_ANSIBLE_FILE_EXTRA_VARS:-}" ]]; then


### PR DESCRIPTION
The allows for setting the POD_ANSIBLE_GIT_BRANCH var to specify which branch to check out.

The default behaviour is preserved i.e. clone the repo and use the default branch When the new env var is set, the specified branch is checked out in the cloned repo.