### PR TITLE
[antelope] Switch to proper upper-constraints

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv =
     SSL_CERT_FILE
     TERM
 deps =
-       -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+       -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}


### PR DESCRIPTION
So far the antelope branch of tcib project was relying on the same upper constraints as the main branch
– so the one of OpenStack master. However, as OpenStack started to drop support for Python 3.9 we are experiencing more and more compatibility issues. The proper upper-constraints for antelope branch is 2023.1 release.