### PR TITLE
Fix AnsibleCollections parameter

### DIFF
--- a/container-images/tcib/base/ansible-tests/run_ansible.sh
+++ b/container-images/tcib/base/ansible-tests/run_ansible.sh
@@ -30,7 +30,7 @@ fi
 
 # Install collections if specified
 if [[ -n "${POD_INSTALL_COLLECTIONS:-}" ]]; then
-    ansible-galaxy collection install "$POD_INSTALL_COLLECTIONS"
+    ansible-galaxy collection install $POD_INSTALL_COLLECTIONS
 fi
 
 # Install collections from requirements.yaml if the file exists


### PR DESCRIPTION
Currently, when the AnsibleCollections parameter in test-operator is used to set multiple collections, it throws an error. To fix this issue, the script should not pass all the collections as one full string. This patch fixes that.