### PR TITLE
Add cinder-wsgi in tcib and reuse it from here

### DIFF
--- a/container-images/kolla/wsgi/cinder-wsgi
+++ b/container-images/kolla/wsgi/cinder-wsgi
@@ -1,0 +1,14 @@
+#! /usr/bin/python3 -sP
+# PBR Generated from 'wsgi_scripts'
+
+import threading
+
+try:
+    from cinder.wsgi.api import application
+except ImportError:
+    from cinder.wsgi.wsgi import initialize_application
+    application = None
+    app_lock = threading.Lock()
+    with app_lock:
+        if application is None:
+            application = initialize_application()

--- a/container-images/tcib/base/os/cinder-base/cinder-api/cinder-api.yaml
+++ b/container-images/tcib/base/os/cinder-base/cinder-api/cinder-api.yaml
@@ -1,7 +1,7 @@
 tcib_actions:
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: mkdir -p /var/www/cgi-bin/cinder && cp -a /usr/bin/cinder-wsgi /var/www/cgi-bin/cinder/cinder-wsgi && sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
-- run: chown -R cinder /var/www/cgi-bin/cinder && chmod 755 /var/www/cgi-bin/cinder/cinder-wsgi
+- run: mkdir -p /var/www/cgi-bin/cinder && chown -R cinder /var/www/cgi-bin/cinder
+- run: cp -a /usr/share/tcib/container-images/kolla/wsgi/cinder-wsgi /var/www/cgi-bin/cinder/cinder-wsgi && chmod 755 /var/www/cgi-bin/cinder/cinder-wsgi
 tcib_packages:
   common:
   - httpd


### PR DESCRIPTION
https://review.opendev.org/c/openstack/cinder/+/960831 drops Remove pbr's wsgi_scripts from setup.cfg and recommends to use should instead reference the Python module path for this service, ``cinder.wsgi.api``,

 This pr adds a modified version of pbr generated cinder-wsgi script to support newer and older release.
    
It also removes httpd conf sed configuration as it is already handled on operator side.


Closes: [OSPCIX-1052](https://issues.redhat.com//browse/OSPCIX-1052)