### PR TITLE
Add ironic-novncproxy container image

### DIFF
--- a/container-images/containers.yaml
+++ b/container-images/containers.yaml
@@ -37,6 +37,7 @@ container_images:
 - imagename: quay.io/podified-master-centos9/openstack-ironic-api:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-ironic-conductor:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-ironic-inspector:current-podified
+- imagename: quay.io/podified-master-centos9/openstack-ironic-novncproxy:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-ironic-pxe:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-ironic-neutron-agent:current-podified
 - imagename: quay.io/podified-master-centos9/openstack-iscsid:current-podified

--- a/container-images/tcib/base/os/ironic-base/ironic-novncproxy/ironic-novncproxy.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-novncproxy/ironic-novncproxy.yaml
@@ -1,0 +1,7 @@
+tcib_actions:
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+tcib_packages:
+  common:
+  - novnc
+  - openstack-ironic-novncproxy
+tcib_user: ironic


### PR DESCRIPTION
This is similar to nova-novncproxy except it includes package openstack-ironic-novncproxy which has existed for 7 months.

Jira: [OSPRH-20211](https://issues.redhat.com//browse/OSPRH-20211)