### PR TITLE
Remove override for load_balancer.test_server_path

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -148,12 +148,6 @@ FAILED_TESTS_FILE="${TEMPEST_LOGS_DIR}/stestr_failing.txt"
 TEMPESTCONF_OVERRIDES="$(echo ${TEMPESTCONF_OVERRIDES} | tr '\n' ' ') identity.v3_endpoint_type public "
 TEMPESTCONF_OVERRIDES+="DEFAULT.log_dir ${TEMPEST_LOGS_DIR} "
 
-# Octavia test-server is built as part of the installation of the python3-octavia-tests-tempest
-# https://github.com/rdo-packages/octavia-tempest-plugin-distgit/blob/rpm-master/python-octavia-tests-tempest.spec#L127
-if [[ ! -z "${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH}" ]]; then
-    TEMPESTCONF_OVERRIDES+="load_balancer.test_server_path ${TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH} "
-fi
-
 # Tempest arguments
 TEMPEST_EXTERNAL_PLUGIN_GIT_URL="${TEMPEST_EXTERNAL_PLUGIN_GIT_URL:-}"
 TEMPEST_EXTERNAL_PLUGIN_CHANGE_URL="${TEMPEST_EXTERNAL_PLUGIN_CHANGE_URL:-}"

--- a/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-all/tempest-all.yaml
@@ -1,6 +1,5 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
-  TEMPESTCONF_OCTAVIA_TEST_SERVER_PATH: /usr/libexec/octavia-tempest-plugin-tests-httpd
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
This override prevents the admin/user from overrriding the path of the test_server application. As we are removing the binary from the tempest container to pull it dynamically from tempestconf, it becomes necessary to be able to set a writeable path for non-root users.

Depends-On: https://review.opendev.org/c/openinfra/python-tempestconf/+/973774

JIRA: [OSPRH-25530](https://issues.redhat.com//browse/OSPRH-25530)