### PR TITLE
pin setuptools < 82 before installing the pip packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
     rev: pylint-2.7.2
     hooks:
       - id: pylint
+        additional_dependencies: ['setuptools<82']

--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -1,9 +1,11 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
+  PIP_BUILD_CONSTRAINT: /tmp/horizon-build-constraints.txt
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: python3 -m pip install --upgrade pip
+- run: python3 -m pip install --upgrade pip 'setuptools<82'
+- run: echo "setuptools<82" > /tmp/horizon-build-constraints.txt
 - run: pip install {{ tcib_packages.pip_packages | join(' ') }}
 - run: cp /usr/share/tcib/container-images/tcib/base/os/horizontest/horizontest_sudoers /etc/sudoers.d/horizontest_sudoers
 - run: chmod 440 /etc/sudoers.d/horizontest_sudoers

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
     SSL_CERT_FILE
     TERM
 deps =
+       setuptools<82
        -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
This fixes the ModuleNotFoundError for pkg_resources which was removed in setuptools 82+. The fix ensures setuptools is pinned to version < 82 in two places:

1. In the pre-commit config for pylint to fix CI failures
2. In the horizontest container build for runtime environment