### PR TITLE
Use rabbitmq rpms from centos stream Messaging SIG repo

### DIFF
--- a/container-images/tcib/base/rabbitmq/rabbitmq.yaml
+++ b/container-images/tcib/base/rabbitmq/rabbitmq.yaml
@@ -1,6 +1,10 @@
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
-- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
+- run: >-
+    dnf -y --repofrompath=extras-common,https://mirror.stream.centos.org/SIGs/{{ tcib_release }}-stream/extras/x86_64/extras-common/
+    --setopt=extras-common.gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras
+    --enablerepo=extras-common install centos-release-rabbitmq-4
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf -y remove centos-release-rabbitmq-4 && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
 - run: cp /usr/share/tcib/container-images/kolla/rabbitmq/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
 tcib_packages:


### PR DESCRIPTION
This commit switches the rabbitmq container image to install rpms coming from the Messaging SIG repo (rabbitmq 4.x).