### PR TITLE
[tcib] horizontest: disable pip build isolation to fix XStatic build …

### DIFF
--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -1,12 +1,12 @@
 tcib_envs:
   USE_EXTERNAL_FILES: true
-  PIP_BUILD_CONSTRAINT: /tmp/horizon-build-constraints.txt
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: python3 -m pip install --upgrade pip 'setuptools<82'
 - run: echo "setuptools<82" > /tmp/horizon-build-constraints.txt
-- run: pip install {{ tcib_packages.pip_packages | join(' ') }}
+- run: pip install --no-build-isolation -c /tmp/horizon-build-constraints.txt horizon
+- run: pip install -c /tmp/horizon-build-constraints.txt {{ tcib_packages.pip_packages | join(' ') }}
 - run: cp /usr/share/tcib/container-images/tcib/base/os/horizontest/horizontest_sudoers /etc/sudoers.d/horizontest_sudoers
 - run: chmod 440 /etc/sudoers.d/horizontest_sudoers
 - run: mkdir -p /var/lib/horizontest/external_files
@@ -32,7 +32,6 @@ tcib_packages:
   - pytest-django
   - pytest-html
   - Django==2.2.28
-  - horizon
   - selenium==3.141.0
   - testtools
   - xvfbwrapper


### PR DESCRIPTION
…failure

The horizontest container build was failing during pip installation with:

ModuleNotFoundError: No module named 'pkg_resources'
ERROR: Failed to build 'XStatic-jQuery'

This occurs because pip build isolation creates a temporary build environment that does not use the pre-installed setuptools package. Some Horizon dependencies (e.g. XStatic-* packages) rely on pkg_resources, which is provided by setuptools, causing the build to fail.

Disable pip build isolation so that the build uses the existing environment where setuptools is already installed.

This ensures Horizon dependencies build correctly during the TCIB container image build.