### PR TITLE
[antelope] Use rabbitmq rpms from centos stream Messaging SIG repo

### DIFF
--- a/container-images/tcib/base/rabbitmq/rabbitmq.yaml
+++ b/container-images/tcib/base/rabbitmq/rabbitmq.yaml
@@ -1,6 +1,7 @@
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
-- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
+- run: dnf -y --enablerepo=extras-common install centos-release-rabbitmq-4
+- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf -y remove centos-release-rabbitmq-4 && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
 - run: cp /usr/share/tcib/container-images/kolla/rabbitmq/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
 tcib_packages:


### PR DESCRIPTION
- Switches the rabbitmq container image to install rpms from the Messaging SIG repo (rabbitmq 4.x)
- Unlike #371 (main branch), the antelope base image already has the `extras-common` repo configured, so we enable it directly instead of using `--repofrompath`, which causes a "Repository extras-common is listed more than once" error
- Supersedes #377
