### PR TITLE
Disable old centos9-rabbitmq repo when installing rabbitmq-server

### DIFF
--- a/container-images/tcib/base/rabbitmq/rabbitmq.yaml
+++ b/container-images/tcib/base/rabbitmq/rabbitmq.yaml
@@ -4,7 +4,7 @@ tcib_actions:
     dnf -y --repofrompath=extras-common,https://mirror.stream.centos.org/SIGs/{{ tcib_release }}-stream/extras/x86_64/extras-common/
     --setopt=extras-common.gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras
     --enablerepo=extras-common install centos-release-rabbitmq-4
-- run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf -y remove centos-release-rabbitmq-4 && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
+- run: dnf -y --disablerepo=centos9-rabbitmq install {{ tcib_packages['common'] | join(' ') }} && dnf -y remove centos-release-rabbitmq-4 && dnf clean all && rm -rf /var/cache/dnf && rm -f /etc/rabbitmq/rabbitmq.conf
 - run: cp /usr/share/tcib/container-images/kolla/rabbitmq/extend_start.sh /usr/local/bin/kolla_extend_start
 - run: chmod 755 /usr/local/bin/kolla_extend_start
 tcib_packages:


### PR DESCRIPTION
- The `centos9-rabbitmq` repo is pre-configured in the base image by the CI repo-setup tooling and contains `rabbitmq-server 3.9.21`
- When installing `rabbitmq-server`, dnf resolves the package from this old repo instead of the Messaging SIG repo added by `centos-release-rabbitmq-4`, resulting in v3.9 being installed instead of v4.x
- Adding `--disablerepo=centos9-rabbitmq` ensures dnf picks up the package from the correct v4 repository