### PR TITLE
[tobiko] Add brackets and quotes

### DIFF
--- a/container-images/tcib/base/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/tobiko/run_tobiko.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -x
 
@@ -12,74 +12,73 @@ function catch_error_if_debug {
 }
 
 # Catch errors when in debug mode
-if [ ${TOBIKO_DEBUG_MODE} == true ]; then
+if [[ "${TOBIKO_DEBUG_MODE}" == true ]]; then
     trap catch_error_if_debug ERR
 fi
 
 # assert mandatory variables have been set
-[ -z "${TOBIKO_TESTENV}" ] && echo "TOBIKO_TESTENV not set" && exit 1
+[[ -z "${TOBIKO_TESTENV}" ]] && echo "TOBIKO_TESTENV not set" && exit 1
 
 # set default values for the required variables
-TOBIKO_VERSION=${TOBIKO_VERSION:-master}
-TOBIKO_PRIVATE_KEY_FILE=${TOBIKO_PRIVATE_KEY_FILE:-id_ecdsa}
-TOBIKO_KEYS_FOLDER=${TOBIKO_KEYS_FOLDER:-${TOBIKO_DIR}/external_files}
-TOBIKO_LOGS_DIR_NAME=${TOBIKO_LOGS_DIR_NAME:-"tobiko"}
+TOBIKO_VERSION="${TOBIKO_VERSION:-master}"
+TOBIKO_PRIVATE_KEY_FILE="${TOBIKO_PRIVATE_KEY_FILE:-id_ecdsa}"
+TOBIKO_KEYS_FOLDER="${TOBIKO_KEYS_FOLDER:-${TOBIKO_DIR}/external_files}"
+TOBIKO_LOGS_DIR_NAME="${TOBIKO_LOGS_DIR_NAME:-"tobiko"}"
 
 # export OS_CLOUD variable
-[ ! -z ${TOBIKO_OS_CLOUD} ] && export OS_CLOUD=${TOBIKO_OS_CLOUD} || export OS_CLOUD=default
+[[ ! -z "${TOBIKO_OS_CLOUD}" ]] && export OS_CLOUD="${TOBIKO_OS_CLOUD}" || export OS_CLOUD=default
 
 # export optional variables, relevant for tox and pytest execution (see tobiko tox.ini file)
-[ ! -z ${TOBIKO_PYTEST_ADDOPTS} ] && export PYTEST_ADDOPTS=${TOBIKO_PYTEST_ADDOPTS}
-[ ! -z ${TOBIKO_RUN_TESTS_TIMEOUT} ] && export TOX_RUN_TESTS_TIMEOUT=${TOBIKO_RUN_TESTS_TIMEOUT}
-[ ! -z ${TOBIKO_PREVENT_CREATE} ] && export TOBIKO_PREVENT_CREATE=${TOBIKO_PREVENT_CREATE}
-[ ! -z ${TOBIKO_NUM_PROCESSES} ] && export TOX_NUM_PROCESSES=${TOBIKO_NUM_PROCESSES}
+[[ ! -z "${TOBIKO_PYTEST_ADDOPTS}" ]] && export PYTEST_ADDOPTS="${TOBIKO_PYTEST_ADDOPTS}"
+[[ ! -z "${TOBIKO_RUN_TESTS_TIMEOUT}" ]] && export TOX_RUN_TESTS_TIMEOUT="${TOBIKO_RUN_TESTS_TIMEOUT}"
+[[ ! -z "${TOBIKO_PREVENT_CREATE}" ]] && export TOBIKO_PREVENT_CREATE="${TOBIKO_PREVENT_CREATE}"
+[[ ! -z "${TOBIKO_NUM_PROCESSES}" ]] && export TOX_NUM_PROCESSES="${TOBIKO_NUM_PROCESSES}"
 
-pushd ${TOBIKO_DIR}
-cp -r ${TOBIKO_SRC_DIR} tobiko
+pushd "${TOBIKO_DIR}"
+cp -r "${TOBIKO_SRC_DIR}" tobiko
 chown tobiko:tobiko -R tobiko
 pushd tobiko
 git pull --rebase
-if [ -n "${TOBIKO_PATCH_REFSPEC}" ]; then
-    git fetch ${TOBIKO_PATCH_REPOSITORY} ${TOBIKO_PATCH_REFSPEC} && git checkout FETCH_HEAD
+if [[ -n "${TOBIKO_PATCH_REFSPEC}" ]]; then
+    git fetch "${TOBIKO_PATCH_REPOSITORY}" "${TOBIKO_PATCH_REFSPEC}" && git checkout FETCH_HEAD
 else
-    git checkout ${TOBIKO_VERSION}
+    git checkout "${TOBIKO_VERSION}"
 fi
 
 # obtain clouds.yaml, ssh private/public keys and tobiko.conf from external_files directory
-if [ ! -z ${USE_EXTERNAL_FILES} ]; then
-    if [ -f $TOBIKO_DIR/external_files/clouds.yaml ]; then
-        mkdir -p $TOBIKO_DIR/.config/openstack
-        cp $TOBIKO_DIR/external_files/clouds.yaml $TOBIKO_DIR/.config/openstack/
+if [[ ! -z "${USE_EXTERNAL_FILES}" ]]; then
+    if [[ -f "${TOBIKO_DIR}/external_files/clouds.yaml" ]]; then
+        mkdir -p "${TOBIKO_DIR}/.config/openstack"
+        cp "${TOBIKO_DIR}/external_files/clouds.yaml" "${TOBIKO_DIR}/.config/openstack/"
     fi
-    if [ -f ${TOBIKO_KEYS_FOLDER}/${TOBIKO_PRIVATE_KEY_FILE} ]; then
-        mkdir -p $TOBIKO_DIR/.ssh
-        cp ${TOBIKO_KEYS_FOLDER}/${TOBIKO_PRIVATE_KEY_FILE}* $TOBIKO_DIR/.ssh/
-        chown tobiko:tobiko $TOBIKO_DIR/.ssh/${TOBIKO_PRIVATE_KEY_FILE}*
+    if [[ -f "${TOBIKO_KEYS_FOLDER}/${TOBIKO_PRIVATE_KEY_FILE}" ]]; then
+        mkdir -p "${TOBIKO_DIR}/.ssh"
+        cp "${TOBIKO_KEYS_FOLDER}/${TOBIKO_PRIVATE_KEY_FILE}"* "${TOBIKO_DIR}/.ssh/"
+        chown tobiko:tobiko "${TOBIKO_DIR}/.ssh/${TOBIKO_PRIVATE_KEY_FILE}"*
     fi
-    [ -f $TOBIKO_DIR/external_files/tobiko.conf ] && cp $TOBIKO_DIR/external_files/tobiko.conf .
+    [[ -f "${TOBIKO_DIR}/external_files/tobiko.conf" ]] && cp "${TOBIKO_DIR}/external_files/tobiko.conf" .
 fi
 
 # run tobiko tests
-python3 -m tox -e ${TOBIKO_TESTENV}
+python3 -m tox -e "${TOBIKO_TESTENV}"
 RETURN_VALUE=$?
 
 # copy logs to external_files
-if [ ! -z ${USE_EXTERNAL_FILES} ]; then
+if [[ ! -z "${USE_EXTERNAL_FILES}" ]]; then
     echo "Copying logs file"
-    TOBIKO_TESTENV_ARR=($TOBIKO_TESTENV)
-    LOG_DIR=${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/${TOBIKO_TESTENV_ARR}/log}
-    cp -rf ${LOG_DIR} ${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/
-    if [ -f tobiko.conf ]; then
-        cp tobiko.conf ${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/
-    elif [ -f /etc/tobiko/tobiko.conf ]; then
-        cp /etc/tobiko/tobiko.conf ${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/
+    TOBIKO_TESTENV_ARR=(${TOBIKO_TESTENV})
+    LOG_DIR="${TOX_REPORT_DIR:-/var/lib/tobiko/tobiko/.tox/${TOBIKO_TESTENV_ARR}/log}"
+    cp -rf "${LOG_DIR}" "${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/"
+    if [[ -f "tobiko.conf" ]]; then
+        cp "tobiko.conf" "${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/"
+    elif [[ -f "/etc/tobiko/tobiko.conf" ]]; then
+        cp "/etc/tobiko/tobiko.conf" "${TOBIKO_DIR}/external_files/${TOBIKO_LOGS_DIR_NAME}/"
     fi
 fi
 
-
 # Keep pod in running state when in debug mode
-if [ ${TOBIKO_DEBUG_MODE} == true ]; then
+if [[ "${TOBIKO_DEBUG_MODE}" == true ]]; then
     sleep infinity
 fi
 
-exit ${RETURN_VALUE}
+exit "${RETURN_VALUE}"


### PR DESCRIPTION
This patch improves the script by double-quoting variables to prevent unintended word splitting and glob expansion. It also transitions conditionals to use double brackets, a standard bash practice that handles empty variables safely and prevents unexpected evaluation errors.

Depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/3849