### PR TITLE
Add script to extract boot assets during container build<JIRA:OSPRH-27413>

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -ex
+
+# Create temporary working directory
+WORKDIR=$(mktemp -d)
+cd ${WORKDIR}
+
+# Create target directory structure
+TARGET_DIR="/usr/share/ironic-operator/var-lib-ironic"
+mkdir -p ${TARGET_DIR}/httpboot
+mkdir -p ${TARGET_DIR}/tftpboot/pxelinux.cfg
+
+# Download boot asset packages (without installing)
+# For x86_64 architecture only
+dnf download ipxe-bootimgs grub2-efi-x64 shim-x64
+
+# Extract files from RPMs
+for rpm in *.rpm; do
+    rpm2cpio ${rpm} | cpio -idmv
+done
+
+# Check for expected EFI directories
+if [ -d "${WORKDIR}/boot/efi/EFI/centos" ]; then
+    efi_dir=centos
+elif [ -d "${WORKDIR}/boot/efi/EFI/redhat" ]; then
+    efi_dir=redhat
+else
+    echo "No EFI directory detected"
+    exit 1
+fi
+
+# Copy iPXE and grub files to both httpboot and tftpboot
+for dir in httpboot tftpboot; do
+    # iPXE files
+    cp ${WORKDIR}/usr/share/ipxe/ipxe-snponly-x86_64.efi ${TARGET_DIR}/${dir}/snponly.efi
+    cp ${WORKDIR}/usr/share/ipxe/undionly.kpxe ${TARGET_DIR}/${dir}/undionly.kpxe
+
+    # ipxe.lkrn is not packaged in RHEL 10, copy if it exists
+    if [ -f "${WORKDIR}/usr/share/ipxe/ipxe.lkrn" ]; then
+        cp ${WORKDIR}/usr/share/ipxe/ipxe.lkrn ${TARGET_DIR}/${dir}/ipxe.lkrn
+    fi
+
+    # UEFI boot files (shim and grub)
+    cp ${WORKDIR}/boot/efi/EFI/${efi_dir}/shimx64.efi ${TARGET_DIR}/${dir}/bootx64.efi
+    cp ${WORKDIR}/boot/efi/EFI/${efi_dir}/grubx64.efi ${TARGET_DIR}/${dir}/grubx64.efi
+done
+
+# Ensure all files are readable
+chmod -R +r ${TARGET_DIR}
+
+# Clean up
+cd /
+rm -rf ${WORKDIR}
+
+echo "Boot assets extracted successfully to ${TARGET_DIR}"

--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
@@ -2,6 +2,7 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf  && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
 - run: echo ". /usr/local/bin/kolla_httpd_setup"> /usr/local/bin/kolla_extend_start && chmod 755 /usr/local/bin/kolla_extend_start
+- run: /bin/bash /usr/share/tcib/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
 tcib_packages:
   common:
   - httpd


### PR DESCRIPTION
**Description:**
Adds `extract-boot-assets.sh` script which uses dnf download and rpm2cpio to download and extract boot assets from ipxe-bootimgs, grub2-efi-x64 and shim packages.
These assets are then moved to `/usr/share/ironic-operator/var-lib-ironic` which will be used by the `pxe-init.sh` script in ironic-operator.  

**Jira Link**: [OSPRH-27413](https://redhat.atlassian.net/browse/OSPRH-27413)

Depends-on: https://github.com/openstack-k8s-operators/ci-framework/pull/3849