### PR TITLE
Pre build ESP image during container build <JIRA:OSPRH-27907>

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
@@ -49,6 +49,21 @@ done
 # Ensure all files are readable
 chmod -R +r ${TARGET_DIR}
 
+# Build an ESP image
+# Uses existing script recipe from ironic-operator pxe-init.sh
+pushd ${TARGET_DIR}/httpboot
+dd if=/dev/zero of=esp.img bs=4096 count=2048
+mkfs.msdos -F 12 -n 'ESP_IMAGE' esp.img
+
+mmd -i esp.img EFI
+mmd -i esp.img EFI/BOOT
+mcopy -i esp.img -v bootx64.efi ::EFI/BOOT
+mcopy -i esp.img -v grubx64.efi ::EFI/BOOT
+mdir -i esp.img ::EFI/BOOT
+popd
+
+echo "ESP image created successfully at ${TARGET_DIR}/httpboot/esp.img"
+
 # Clean up
 cd /
 rm -rf ${WORKDIR}

--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/ironic-pxe.yaml
@@ -2,7 +2,7 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: sed -i -r 's,^(Listen 80),#\1,' /etc/httpd/conf/httpd.conf  && sed -i -r 's,^(Listen 443),#\1,' /etc/httpd/conf.d/ssl.conf
 - run: echo ". /usr/local/bin/kolla_httpd_setup"> /usr/local/bin/kolla_extend_start && chmod 755 /usr/local/bin/kolla_extend_start
-- run: /bin/bash /usr/share/tcib/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
+- run: dnf -y install dosfstools mtools && /bin/bash /usr/share/tcib/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh && dnf -y remove dosfstools mtools && dnf clean all && rm -rf /var/cache/dnf
 tcib_packages:
   common:
   - httpd
@@ -13,5 +13,3 @@ tcib_packages:
   - grub2-efi-x64
   - shim
   - iproute
-  - dosfstools
-  - mtools


### PR DESCRIPTION
Description:
This PR pre-builds `esp.img` in the container image build using [the same recipe ](https://github.com/openstack-k8s-operators/ironic-operator/blob/b8fc3a4b05217d5b450a69e6f2064e1e471f3f3c/templates/common/bin/pxe-init.sh#L83-L98) as `pxe-init.sh` in ironic-operator instead of building it when the container starts up. The packages dosfstools and mtools are installed temporarily during the build process and removed at the end.  

Jira LInk: [OSPRH-27907](https://redhat.atlassian.net/browse/OSPRH-27907)