### PR TITLE
Change directory layout and include aarch64 iPXE and GRUB boot assets in container image<JIRA:OSPRH-27905>

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
@@ -6,52 +6,82 @@ set -ex
 WORKDIR=$(mktemp -d)
 cd ${WORKDIR}
 
-# Create target directory structure
+# Create target directory structure with arch-specific subdirectories
 TARGET_DIR="/usr/share/ironic-operator/var-lib-ironic"
-mkdir -p ${TARGET_DIR}/httpboot
+mkdir -p ${TARGET_DIR}/httpboot/x86_64
+mkdir -p ${TARGET_DIR}/httpboot/aarch64
+mkdir -p ${TARGET_DIR}/tftpboot/x86_64
+mkdir -p ${TARGET_DIR}/tftpboot/aarch64
 mkdir -p ${TARGET_DIR}/tftpboot/pxelinux.cfg
 
-# Download boot asset packages (without installing)
-# For x86_64 architecture only
-dnf download ipxe-bootimgs grub2-efi-x64 shim-x64
+# Download boot asset packages for x86_64
+mkdir -p ${WORKDIR}/x86_64
+cd ${WORKDIR}/x86_64
+dnf download ipxe-bootimgs-x86 grub2-efi-x64 shim-x64
 
-# Extract files from RPMs
+# Extract x86_64 RPMs
 for rpm in *.rpm; do
     rpm2cpio ${rpm} | cpio -idmv
 done
 
 # Check for expected EFI directories
-if [ -d "${WORKDIR}/boot/efi/EFI/centos" ]; then
-    efi_dir=centos
-elif [ -d "${WORKDIR}/boot/efi/EFI/redhat" ]; then
-    efi_dir=redhat
+if [ -d "${WORKDIR}/x86_64/boot/efi/EFI/centos" ]; then
+    efi_dir_x86=centos
+elif [ -d "${WORKDIR}/x86_64/boot/efi/EFI/redhat" ]; then
+    efi_dir_x86=redhat
 else
-    echo "No EFI directory detected"
+    echo "No x86_64 EFI directory detected"
     exit 1
 fi
 
-# Copy iPXE and grub files to both httpboot and tftpboot
+# Download boot asset packages for aarch64
+mkdir -p ${WORKDIR}/aarch64
+cd ${WORKDIR}/aarch64
+dnf download --forcearch=aarch64 ipxe-bootimgs-aarch64 grub2-efi-aa64 shim-aa64
+
+# Extract aarch64 RPMs
+for rpm in *.rpm; do
+    rpm2cpio ${rpm} | cpio -idmv
+done
+
+# Check for expected EFI directories for aarch64
+if [ -d "${WORKDIR}/aarch64/boot/efi/EFI/centos" ]; then
+    efi_dir_aa64=centos
+elif [ -d "${WORKDIR}/aarch64/boot/efi/EFI/redhat" ]; then
+    efi_dir_aa64=redhat
+else
+    echo "No aarch64 EFI directory detected"
+    exit 1
+fi
+
+# Copy x86_64 iPXE and grub files to arch-specific directories
 for dir in httpboot tftpboot; do
-    # iPXE files
-    cp ${WORKDIR}/usr/share/ipxe/ipxe-snponly-x86_64.efi ${TARGET_DIR}/${dir}/snponly.efi
-    cp ${WORKDIR}/usr/share/ipxe/undionly.kpxe ${TARGET_DIR}/${dir}/undionly.kpxe
+    # x86_64 iPXE files
+    cp ${WORKDIR}/x86_64/usr/share/ipxe/ipxe-snponly-x86_64.efi ${TARGET_DIR}/${dir}/x86_64/snponly.efi
+    cp ${WORKDIR}/x86_64/usr/share/ipxe/undionly.kpxe ${TARGET_DIR}/${dir}/x86_64/undionly.kpxe
 
     # ipxe.lkrn is not packaged in RHEL 10, copy if it exists
-    if [ -f "${WORKDIR}/usr/share/ipxe/ipxe.lkrn" ]; then
-        cp ${WORKDIR}/usr/share/ipxe/ipxe.lkrn ${TARGET_DIR}/${dir}/ipxe.lkrn
+    if [ -f "${WORKDIR}/x86_64/usr/share/ipxe/ipxe.lkrn" ]; then
+        cp ${WORKDIR}/x86_64/usr/share/ipxe/ipxe.lkrn ${TARGET_DIR}/${dir}/x86_64/ipxe.lkrn
     fi
 
-    # UEFI boot files (shim and grub)
-    cp ${WORKDIR}/boot/efi/EFI/${efi_dir}/shimx64.efi ${TARGET_DIR}/${dir}/bootx64.efi
-    cp ${WORKDIR}/boot/efi/EFI/${efi_dir}/grubx64.efi ${TARGET_DIR}/${dir}/grubx64.efi
+    # x86_64 UEFI boot files (shim and grub)
+    cp ${WORKDIR}/x86_64/boot/efi/EFI/${efi_dir_x86}/shimx64.efi ${TARGET_DIR}/${dir}/x86_64/bootx64.efi
+    cp ${WORKDIR}/x86_64/boot/efi/EFI/${efi_dir_x86}/grubx64.efi ${TARGET_DIR}/${dir}/x86_64/grubx64.efi
+
+    # aarch64 iPXE files
+    cp ${WORKDIR}/aarch64/usr/share/ipxe/arm64-efi/snponly.efi ${TARGET_DIR}/${dir}/aarch64/snponly.efi
+
+    # aarch64 UEFI boot files (shim and grub)
+    cp ${WORKDIR}/aarch64/boot/efi/EFI/${efi_dir_aa64}/shimaa64.efi ${TARGET_DIR}/${dir}/aarch64/bootaa64.efi
+    cp ${WORKDIR}/aarch64/boot/efi/EFI/${efi_dir_aa64}/grubaa64.efi ${TARGET_DIR}/${dir}/aarch64/grubaa64.efi
 done
 
 # Ensure all files are readable
 chmod -R +r ${TARGET_DIR}
 
-# Build an ESP image
-# Uses existing script recipe from ironic-operator pxe-init.sh
-pushd ${TARGET_DIR}/httpboot
+# Build x86_64 ESP image
+pushd ${TARGET_DIR}/httpboot/x86_64
 dd if=/dev/zero of=esp.img bs=4096 count=2048
 mkfs.msdos -F 12 -n 'ESP_IMAGE' esp.img
 
@@ -62,7 +92,39 @@ mcopy -i esp.img -v grubx64.efi ::EFI/BOOT
 mdir -i esp.img ::EFI/BOOT
 popd
 
-echo "ESP image created successfully at ${TARGET_DIR}/httpboot/esp.img"
+echo "x86_64 ESP image created successfully at ${TARGET_DIR}/httpboot/x86_64/esp.img"
+
+# Build aarch64 ESP image
+pushd ${TARGET_DIR}/httpboot/aarch64
+dd if=/dev/zero of=esp.img bs=4096 count=2048
+mkfs.msdos -F 12 -n 'ESP_IMAGE' esp.img
+
+mmd -i esp.img EFI
+mmd -i esp.img EFI/BOOT
+mcopy -i esp.img -v bootaa64.efi ::EFI/BOOT
+mcopy -i esp.img -v grubaa64.efi ::EFI/BOOT
+mdir -i esp.img ::EFI/BOOT
+popd
+
+echo "aarch64 ESP image created successfully at ${TARGET_DIR}/httpboot/aarch64/esp.img"
+
+# Create compatibility symlinks in httpboot and tftpboot for backwards compatibility
+for dir in httpboot tftpboot; do
+    pushd ${TARGET_DIR}/${dir}
+    ln -sf x86_64/snponly.efi snponly.efi
+    ln -sf x86_64/undionly.kpxe undionly.kpxe
+    if [ -f "x86_64/ipxe.lkrn" ]; then
+        ln -sf x86_64/ipxe.lkrn ipxe.lkrn
+    fi
+    ln -sf x86_64/bootx64.efi bootx64.efi
+    ln -sf x86_64/grubx64.efi grubx64.efi
+    if [ "${dir}" = "httpboot" ]; then
+        ln -sf x86_64/esp.img esp.img
+    fi
+    popd
+done
+
+echo "Compatibility symlinks created in ${TARGET_DIR}/httpboot and ${TARGET_DIR}/tftpboot"
 
 # Clean up
 cd /


### PR DESCRIPTION
**Description:**
Creates architecture specific subdirectories for `x86_64` and `aarch64` and modifies existing code to download boot asset packages for both. These assets are then copied to their specific directories and a soft link is placed for `x86_64` for backwards compatibility with the existing "init-pxe.sh" file in ironic-operator for RHOSO-18. 

Jira Link: [OSPRH-27905](https://redhat.atlassian.net/browse/OSPRH-27905)