### PR TITLE
[tobiko] Remove quotes for TOBIKO_TESTENV variable

### DIFF
--- a/container-images/tcib/base/tobiko/run_tobiko.sh
+++ b/container-images/tcib/base/tobiko/run_tobiko.sh
@@ -60,7 +60,8 @@ if [[ ! -z "${USE_EXTERNAL_FILES}" ]]; then
 fi
 
 # run tobiko tests
-python3 -m tox -e "${TOBIKO_TESTENV}"
+# Note(kstrenko): Unquoted to enable word splitting for tox -- syntax
+python3 -m tox -e ${TOBIKO_TESTENV}
 RETURN_VALUE=$?
 
 # copy logs to external_files


### PR DESCRIPTION
Recently a change added quotes to Tobiko variables to follow best practices. However, the environment variable quotation prevented using "scenario -- path/to/test.py" tox syntax, where word splitting is required to pass arguments after --. This change removes quotes to enable this use case.