### PR TITLE
Remove barbican-tempest-plugin from tempest-extras

### DIFF
--- a/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
+++ b/container-images/tcib/base/os/tempest/tempest-extras/tempest-extras.yaml
@@ -4,8 +4,6 @@ tcib_actions:
 - run: cd /usr/local/whitebox-tempest-plugin; pip install -e .
 - run: cd /usr/local; git clone https://github.com/openstack/tempest-stress
 - run: cd /usr/local/tempest-stress; pip install -e .
-- run: cd /usr/local; git clone https://opendev.org/openstack/barbican-tempest-plugin.git
-- run: cd /usr/local/barbican-tempest-plugin; pip install -e .
 
 tcib_packages:
   common:


### PR DESCRIPTION
## Summary

Remove the `barbican-tempest-plugin` git clone from the tempest-extras
container build template. The upstream master branch now requires
Python >=3.10 ([merge 867f18d788](https://github.com/openstack/barbican-tempest-plugin/commit/867f18d7886acd6bd658b62854b302c0efc078d6),
May 15 2026), but the container ships Python 3.9.18.

The clone is redundant - `whitebox-tempest-plugin` already installs
`barbican-tempest-plugin==4.5.0` from PyPI as a dependency
([build log evidence](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/logs/d6b/components-integration/d6b666da9f0f4dc59cbd8600340c0a1f/ci-framework-data/logs/1ec421a0-fc56-45b3-a48e-1dfcba9f527b/base/os/tempest/tempest-extras/tempest-extras-build.log),
lines 107-114). The git clone then overwrites this with broken
4.5.1.dev12 from master (line 148: `ERROR: Package
'barbican-tempest-plugin' requires a different Python: 3.9.18
not in '>=3.10'`).

Same pattern as manila-tempest-plugin removal in #356.

## Impact

- Unblocks keystone component pipeline (tcib failing since May 16,
  all 6 downstream jobs SKIPPED)
- Affects ALL component pipelines that build tempest-extras
  (currently only keystone triggers daily - other components
  skip tcib when hash unchanged)

## Evidence

- [Failing tcib build (May 17)](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/d6b666da9f0f4dc59cbd8600340c0a1f) - barbican-tempest-plugin Python >=3.10 error
- [Failing tcib build (May 16)](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/bcf9d39717c541c4b8ccaf4f5fd0fa55) - same error
- [Passing tcib build (May 15)](https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/zuul/t/components-integration/build/ec0f330c3b4a470eb42d7b4fbe60cee0) - last success before upstream merge
- [Manila precedent PR #356](https://github.com/openstack-k8s-operators/tcib/pull/356) - identical fix for manila-tempest-plugin (Jan 2026)

## CIX

- [OSPCIX-1321](https://redhat.atlassian.net/browse/OSPCIX-1321) - keystone multiple jobs failing