### PR TITLE
openstackclient: Do not replace sh with bash

### DIFF
--- a/container-images/tcib/base/openstackclient/openstackclient.yaml
+++ b/container-images/tcib/base/openstackclient/openstackclient.yaml
@@ -3,8 +3,6 @@ tcib_actions:
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: openstack complete | tee /etc/bash_completion.d/osc.bash_completion > /dev/null
 - run: baremetal complete | tee /etc/bash_completion.d/baremetal.bash_completion > /dev/null
-# ensure "oc rsh" uses bash by default
-- run: rm /bin/sh && ln -s /bin/bash /bin/sh
 tcib_packages:
   common:
   - ceph-common


### PR DESCRIPTION
This command tainted the container as modified in a way which is triggering a container image integrity tool, with the message:

  msg="found disallowed modification in layer" check=HasModifiedFiles file=usr/bin/sh

This change makes no changes to behaviour since /bin/sh is a symlink to /bin/bash anyway, so the intention of having a properly formatted $PS1 when running "oc rsh openstackclient" was not achieved.

Jira: [OSPRH-29946](https://redhat.atlassian.net/browse/OSPRH-29946)