### PR TITLE
Skip unavailable repos when downloading aarch64 boot assets <JIRA:OSPCIX-1386>

### DIFF
--- a/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
+++ b/container-images/tcib/base/os/ironic-base/ironic-pxe/extract-boot-assets.sh
@@ -37,7 +37,7 @@ fi
 # Download boot asset packages for aarch64
 mkdir -p ${WORKDIR}/aarch64
 cd ${WORKDIR}/aarch64
-dnf download --forcearch=aarch64 ipxe-bootimgs-aarch64 grub2-efi-aa64 shim-aa64
+dnf download --forcearch=aarch64 --setopt=*.skip_if_unavailable=True ipxe-bootimgs-aarch64 grub2-efi-aa64 shim-aa64
 
 # Extract aarch64 RPMs
 for rpm in *.rpm; do


### PR DESCRIPTION
The `ironic-pxe` container build uses `--forcearch=aarch64` to download aarch64 boot assets on an x86_64 build host. This forces dnf to check the ceph repo to check for aarch64 versions. Since this doesn't exist on Ceph 7.1 it causes a 404 and a failed build. 
Add  `--setopt=*.skip_if_unavailable=True` to the dnf download command so repos not containing boot assets are skipped and obtain it from those that contain it. 

Fixes: [OSPRH-27905](https://redhat.atlassian.net/browse/OSPRH-27905)

Jira Link: [OSPCIX-1386](https://redhat.atlassian.net/browse/OSPCIX-1386)