### PR TITLE
Install frr in neutron-ovn-agent

### DIFF
--- a/container-images/tcib/base/os/neutron-base/neutron-agent-base/neutron-ovn-agent/neutron-ovn-agent.yaml
+++ b/container-images/tcib/base/os/neutron-base/neutron-agent-base/neutron-ovn-agent/neutron-ovn-agent.yaml
@@ -1,6 +1,9 @@
 tcib_actions:
+- run: bash /usr/local/bin/uid_gid_manage frrvty frr
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
+- run: mkdir -p /var/lock/subsys && chown "frr:" /var/lock/subsys
 tcib_packages:
   common:
+  - frr
   - openstack-neutron-ovn-agent
 tcib_user: neutron


### PR DESCRIPTION
Neutron ovn agent evpn extension needs access to `vtysh` command. Unfortunately, `vtysh` does not come as a standalone client and must be installed as part of frr package.

JIRA:  https://redhat.atlassian.net/browse/OSPRH-31097