### PR TITLE
Fix horizontest admin auth by loading password from OS cloud config

### DIFF
--- a/container-images/tcib/base/os/horizontest/run_horizontest.sh
+++ b/container-images/tcib/base/os/horizontest/run_horizontest.sh
@@ -39,8 +39,12 @@ SERVICES_REGION_BTN_TEXT_PATTERN="Managing Region {region}"
 SERVICES_REGION_DROPDOWN_XPATH=".//li[@id='services_region_switcher']"
 
 # assert mandatory variables have been set
-[[ -z ${ADMIN_USERNAME} ]] && echo "ADMIN_USERNAME not set" && exit 1
-[[ -z ${ADMIN_PASSWORD} ]] && echo "ADMIN_PASSWORD not set" && exit 1
+if [[ -z "${ADMIN_USERNAME}" ]]; then
+    ADMIN_USERNAME=$(python3 -c "from openstack.config import OpenStackConfig; print(OpenStackConfig().get_one(cloud='default').auth['username'])")
+fi
+if [[ -z "${ADMIN_PASSWORD}" ]]; then
+    ADMIN_PASSWORD=$(python3 -c "from openstack.config import OpenStackConfig; print(OpenStackConfig().get_one(cloud='default').auth['password'])")
+fi
 [[ -z ${DASHBOARD_URL} ]] && echo "DASHBOARD_URL not set" && exit 1
 [[ -z ${AUTH_URL} ]] && echo "AUTH_URL not set" && exit 1
 [[ -z ${REPO_URL} ]] && REPO_URL="https://review.opendev.org/openstack/horizon"


### PR DESCRIPTION
The pod injects ADMIN_PASSWORD=12345678, which does not match the RHOSO admin credentials used by --os-cloud default after switch to passwords and secrets dynamic generation. Read the password via OpenStackConfig so horizon.conf matches the working CLI auth.