### PR TITLE
Enable TLS verification by default for buildah pull and push

### DIFF
--- a/tcib/builder/buildah.py
+++ b/tcib/builder/buildah.py
@@ -39,7 +39,8 @@ class BuildahBuilder(base.BaseBuilder):
     def __init__(self, work_dir, deps, base='fedora', img_type='binary',
                  tag='latest', namespace='master',
                  registry_address='127.0.0.1:8787', push_containers=True,
-                 volumes=[], excludes=[], build_timeout=None, debug=False):
+                 volumes=[], excludes=[], build_timeout=None, debug=False,
+                 tls_verify=True):
         """Setup the parameters to build with Buildah.
 
         :params work_dir: Directory where the Dockerfiles or Containerfiles
@@ -63,6 +64,8 @@ class BuildahBuilder(base.BaseBuilder):
         :params excludes: List of images to skip. Default to [].
         :params build_timeout: Timeout. Default to BUILD_TIMEOUT
         :params debug: Enable debug flag. Default to False.
+        :params tls_verify: Enable TLS verification for registry
+            communication. Default to True.
         """
 
         logging.register_options(CONF)
@@ -86,6 +89,7 @@ class BuildahBuilder(base.BaseBuilder):
         self.volumes = volumes
         self.excludes = excludes
         self.debug = debug
+        self.tls_verify = tls_verify
         # Each container image has a Dockerfile or a Containerfile.
         # Buildah needs to know the base directory later.
         self.cont_map = {os.path.basename(root): root for root, dirs,
@@ -162,10 +166,6 @@ class BuildahBuilder(base.BaseBuilder):
             Containerfile and other files are located to build the image.
         """
 
-        # 'buildah bud' is the command we want because Kolla uses Dockefile to
-        # build images.
-        # TODO(emilien): Stop ignoring TLS. The deployer should either secure
-        # the registry or add it to insecure_registries.
         logfile = container_build_path + '/' + container_name + '-build.log'
 
         # TODO(ramishra) Hack to make the logfile readable by current user,
@@ -182,8 +182,10 @@ class BuildahBuilder(base.BaseBuilder):
         bud_args.extend(['--label', 'tcib_build_tag=%s' % self.tag])
         # TODO(aschultz): drop --format docker when oci format is properly
         # supported by the undercloud registry
-        bud_args.extend(['--format', 'docker', '--tls-verify=False',
-                         '--logfile', logfile, '-t',
+        bud_args.extend(['--format', 'docker'])
+        if not self.tls_verify:
+            bud_args.append('--tls-verify=false')
+        bud_args.extend(['--logfile', logfile, '-t',
                          self._get_destination(container_name),
                          container_build_path])
         args = self.buildah_cmd + bud_args
@@ -209,12 +211,13 @@ class BuildahBuilder(base.BaseBuilder):
             the registry address, namespace, base, img_type (optional),
             container name and tag.
         """
-        # TODO(emilien): Stop ignoring TLS. The deployer should either secure
-        # the registry or add it to insecure_registries.
         # TODO(emilien) We need to figure out how we can push to something
         # else than a Docker registry.
-        args = self.buildah_cmd + ['push', '--tls-verify=False', destination,
-                                   'docker://' + destination]
+        push_args = ['push']
+        if not self.tls_verify:
+            push_args.append('--tls-verify=false')
+        push_args.extend([destination, 'docker://' + destination])
+        args = self.buildah_cmd + push_args
         self.log.info("Pushing %s image with: %s" %
                       (destination, ' '.join(args)))
         if self.debug:

--- a/tcib/client/container_image.py
+++ b/tcib/client/container_image.py
@@ -275,6 +275,17 @@ class Build(command.Command):
             type=int,
             help=_("Build timeout in seconds.")
         )
+        parser.add_argument(
+            "--no-tls-verify",
+            dest="tls_verify",
+            default=True,
+            action="store_false",
+            help=_(
+                "Disable TLS verification when pulling/pushing images. "
+                "WARNING: This makes registry communication vulnerable to "
+                "MITM attacks. Only use for local/development registries."
+            ),
+        )
         return parser
 
     def imagename_to_regex(self, imagename):
@@ -754,7 +765,8 @@ class Build(command.Command):
                 volumes=volumes,
                 excludes=list(set(excludes)),
                 build_timeout=parsed_args.build_timeout,
-                debug=self.app.options.debug
+                debug=self.app.options.debug,
+                tls_verify=parsed_args.tls_verify
             )
             try:
                 bb.build_all()

--- a/tcib/tests/test_buildah.py
+++ b/tcib/tests/test_buildah.py
@@ -113,11 +113,33 @@ class TestBuildahBuilder(base.TestCase):
         buildah_cmd_build = ['--log-level=debug', 'bud', '--net=host',
                              '--loglevel=3', '--label',
                              'tcib_build_tag=latest', '--format', 'docker',
-                             '--tls-verify=False', '--logfile',
+                             '--logfile',
                              logfile, '-t', dest, container_build_path]
         args.extend(buildah_cmd_build)
         bb(WORK_DIR, DEPS, debug=True).build('fedora-base',
                                              container_build_path)
+        mock_process.assert_called_once_with(
+            *args,
+            check_exit_code=True,
+            run_as_root=False,
+            use_standard_locale=True
+        )
+
+    @mock.patch.object(process, 'execute', autospec=True)
+    @mock.patch.object(pathlib.Path, 'touch', autospec=True)
+    def test_build_tls_verify_disabled(self, mock_touch, mock_process):
+        args = copy.copy(BUILDAH_CMD_BASE)
+        dest = '127.0.0.1:8787/master/fedora-binary-fedora-base:latest'
+        container_build_path = WORK_DIR + '/' + 'fedora-base'
+        logfile = '/tmp/kolla/fedora-base/fedora-base-build.log'
+        buildah_cmd_build = ['--log-level=debug', 'bud', '--net=host',
+                             '--loglevel=3', '--label',
+                             'tcib_build_tag=latest', '--format', 'docker',
+                             '--tls-verify=false', '--logfile',
+                             logfile, '-t', dest, container_build_path]
+        args.extend(buildah_cmd_build)
+        bb(WORK_DIR, DEPS, debug=True, tls_verify=False).build(
+            'fedora-base', container_build_path)
         mock_process.assert_called_once_with(
             *args,
             check_exit_code=True,
@@ -134,7 +156,7 @@ class TestBuildahBuilder(base.TestCase):
         logfile = '/tmp/kolla/fedora-base/fedora-base-build.log'
         buildah_cmd_build = ['bud', '--net=host', '--label',
                              'tcib_build_tag=latest', '--format',
-                             'docker', '--tls-verify=False',
+                             'docker',
                              '--logfile', logfile, '-t', dest,
                              container_build_path]
         args.extend(buildah_cmd_build)
@@ -159,7 +181,6 @@ class TestBuildahBuilder(base.TestCase):
                              '--volume', '/etc/dir2:/dir2',
                              '--label', 'tcib_build_tag=latest',
                              '--format', 'docker',
-                             '--tls-verify=False',
                              '--logfile', logfile, '-t', dest,
                              container_build_path]
         args.extend(buildah_cmd_build)
@@ -182,10 +203,21 @@ class TestBuildahBuilder(base.TestCase):
     def test_push(self, mock_process):
         args = copy.copy(BUILDAH_CMD_BASE)
         dest = '127.0.0.1:8787/master/fedora-binary-fedora-base:latest'
-        buildah_cmd_push = ['push', '--tls-verify=False', dest,
-                            'docker://' + dest]
+        buildah_cmd_push = ['push', dest, 'docker://' + dest]
         args.extend(buildah_cmd_push)
         bb(WORK_DIR, DEPS).push(dest)
+        mock_process.assert_called_once_with(
+            *args, run_as_root=False, use_standard_locale=True
+        )
+
+    @mock.patch.object(process, 'execute', autospec=True)
+    def test_push_tls_verify_disabled(self, mock_process):
+        args = copy.copy(BUILDAH_CMD_BASE)
+        dest = '127.0.0.1:8787/master/fedora-binary-fedora-base:latest'
+        buildah_cmd_push = ['push', '--tls-verify=false', dest,
+                            'docker://' + dest]
+        args.extend(buildah_cmd_push)
+        bb(WORK_DIR, DEPS, tls_verify=False).push(dest)
         mock_process.assert_called_once_with(
             *args, run_as_root=False, use_standard_locale=True
         )


### PR DESCRIPTION
Registry TLS verification was unconditionally disabled (--tls-verify=False) for both buildah bud and buildah push, exposing all registry communication to MITM attacks (CWE-295).

jira: [OSPRH-33433](https://redhat.atlassian.net/browse/OSPRH-33433)