### PR TITLE
[tempest] Fix phantom test results from timing-data archive

### DIFF
--- a/container-images/tcib/base/os/tempest/run_tempest.sh
+++ b/container-images/tcib/base/os/tempest/run_tempest.sh
@@ -89,6 +89,7 @@
 
 set -x
 RETURN_VALUE=0
+TEMPEST_TESTS_RAN=false
 
 HOMEDIR=/var/lib/tempest
 TEMPEST_PATH="${HOMEDIR}/"
@@ -344,14 +345,19 @@ function run_tempest {
     upload_extra_images
 
     if [[ -n "${TEMPEST_TIMING_DATA_URL:-}" ]]; then
-        curl -L "${TEMPEST_TIMING_DATA_URL}" | tar -xz --strip-components=1 -C "${TEMPEST_DIR}/.stestr"
+        curl -L "${TEMPEST_TIMING_DATA_URL}" | tar -xz --strip-components=1 -C "${TEMPEST_DIR}/.stestr" --wildcards '*/times.dbm*'
     fi
 
     mkdir -p "${TEMPEST_LOGS_DIR}"
 
-    discover_tempest_config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES} \
-    && tempest run ${TEMPEST_ARGS}
-    RETURN_VALUE=$?
+    if discover_tempest_config ${TEMPESTCONF_ARGS} ${TEMPESTCONF_OVERRIDES}; then
+        TEMPEST_TESTS_RAN=true
+        tempest run ${TEMPEST_ARGS}
+        RETURN_VALUE=$?
+    else
+        RETURN_VALUE=$?
+        echo "discover-tempest-config failed (rc=${RETURN_VALUE}), skipping tempest run"
+    fi
 
     run_tempest_cleanup
 
@@ -574,11 +580,15 @@ fi
 
 print_config_files
 save_config_files
-move_tempest_log tempest_results.log
-generate_test_results tempest_results
 
-rerun_failed_tests
-check_expected_failures
+if [ "${TEMPEST_TESTS_RAN}" = true ]; then
+    move_tempest_log tempest_results.log
+    generate_test_results tempest_results
+    rerun_failed_tests
+    check_expected_failures
+else
+    echo "Tests did not run, skipping result collection"
+fi
 
 # Keep pod in running state when in debug mode
 if [ "${TEMPEST_DEBUG_MODE}" == true ]; then


### PR DESCRIPTION
When `discover-tempest-config` fails and `tempest run` never executes,
`stestr last --subunit` picks up old test results from the timing-data
archive and reports them as if they passed in this run.

## Root Cause

The [timing-data archive](https://gitlab.cee.redhat.com/ci-framework/timing-data)
contains the full `.stestr/` directory from previous runs — including old test
result files — not just the timing database that stestr uses for test scheduling.
When `discover-tempest-config` fails, those old results are picked up by the
unconditional `generate_test_results` call.

Example: https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/logs/25f/components-integration/25ffb2f08d194ccba0123053d8dfb21b/

## Fix

Two changes in `run_tempest.sh`:

1. **Extract only timing database files** from the archive (`times.dbm*`)
   instead of the entire `.stestr/` directory. stestr uses `dbm.dumb` which
   stores timing data as three files: `.bak`, `.dat`, `.dir`.

2. **Guard result collection** — track whether `tempest run` actually executed
   and skip `move_tempest_log` + `generate_test_results` when it did not.

Both layers are complementary: the tar filter prevents old results from being
extracted, and the execution guard prevents result collection when tests did
not run.

## Testing

- Verified `stestr` source: uses `from dbm import dumb as my_dbm` for `times.dbm`
- Verified archive structure matches `save_config_files` output
- Tested tar wildcard extraction locally (only `times.dbm.*` files extracted)
- Verified `RETURN_VALUE` semantics are preserved (3 cases: both succeed, discover fails, tempest fails)
- Verified bash ERR trap interaction: `if` condition suppresses ERR trap (matching original `&&` behavior)
- Verified `rerun_failed_tests` and `check_expected_failures` handle missing `FAILED_TESTS_FILE` correctly
- bashate passes clean

Closes: https://redhat.atlassian.net/browse/OSPNW-1674