### PR TITLE
Tighten tcib sudoers rules

### DIFF
--- a/container-images/kolla/base/start.sh
+++ b/container-images/kolla/base/start.sh
@@ -2,10 +2,9 @@
 set -o errexit
 set -o xtrace
 
-# Processing /var/lib/kolla/config_files/config.json as root.  This is necessary
-# to permit certain files to be controlled by the root user which should
-# not be writable by the dropped-privileged user, especially /run_command
-sudo -E kolla_set_configs
+# Process config as root because `/run_command` must stay root-controlled.
+# Use sudoers `env_keep` instead of `sudo -E`.
+sudo kolla_set_configs
 CMD=$(cat /run_command)
 ARGS=""
 

--- a/container-images/kolla/base/sudoers
+++ b/container-images/kolla/base/sudoers
@@ -3,17 +3,18 @@
 # kolla_set_configs via sudo as the root user which is necessary to protect
 # the immutability of the container
 
-# anyone in the kolla group may sudo -E (set the environment)
-Defaults: %kolla setenv
+# Avoid `setenv` so untrusted environment variables cannot reach root helpers.
+# Keep the required Kolla variables for both root and `%kolla` callers.
 Defaults secure_path="/var/lib/kolla/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults:root env_keep += "KOLLA_CONFIG_STRATEGY KOLLA_CONFIG_FILES HOME LANG"
+Defaults:%kolla env_keep += "KOLLA_CONFIG_STRATEGY KOLLA_CONFIG_FILES HOME LANG DB_ROOT_PASSWORD DB_MAX_TIMEOUT"
 
-# root may run any commands via sudo as the network seervice user.  This is
-# neededfor database migrations of existing services which have not been
-# converted to run as a non-root user, but instead do that via sudo -E glance
+# root may run commands as a service user for database migrations etc.
 root ALL=(ALL) ALL
 
-# anyone in the kolla group may run /usr/local/bin/kolla_set_configs as the
-# root user via sudo without password confirmation
-%kolla ALL=(root) NOPASSWD: /usr/local/bin/kolla*
+# Explicit helper paths avoid wildcard-based sudo escalation.
+%kolla ALL=(root) NOPASSWD: /usr/local/bin/kolla_set_configs
+%kolla ALL=(root) NOPASSWD: /usr/local/bin/kolla_copy_cacerts
+%kolla ALL=(root) NOPASSWD: /usr/local/bin/kolla_security_reset
 
 #includedir /etc/sudoers.d

--- a/container-images/kolla/mariadb/extend_start.sh
+++ b/container-images/kolla/mariadb/extend_start.sh
@@ -17,7 +17,7 @@ function bootstrap_db {
         fi
     done
 
-    sudo -E kolla_security_reset
+    sudo kolla_security_reset
     mysql -u root --password="${DB_ROOT_PASSWORD}" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}' WITH GRANT OPTION;"
     mysql -u root --password="${DB_ROOT_PASSWORD}" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${DB_ROOT_PASSWORD}' WITH GRANT OPTION;"
     mysqladmin -uroot -p"${DB_ROOT_PASSWORD}" shutdown

--- a/container-images/tcib/base/ansible-tests/ansibleTests.yaml
+++ b/container-images/tcib/base/ansible-tests/ansibleTests.yaml
@@ -4,8 +4,7 @@ tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages.common | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
 - run: pip3 install ansible openstacksdk
-- run: cp /usr/share/tcib/container-images/tcib/base/ansible-tests/ansible_sudoers /etc/sudoers.d/ansible_sudoers
-- run: chmod 440 /etc/sudoers.d/ansible_sudoers
+# No sudoers: ansible-tests do not need root.
 - run: cp /usr/share/tcib/container-images/tcib/base/ansible-tests/run_ansible.sh /usr/local/bin/run_ansible.sh
 - run: chmod +x /usr/local/bin/run_ansible.sh
 - run: chown -R ansible:ansible /var/lib/ansible

--- a/container-images/tcib/base/ansible-tests/ansible_sudoers
+++ b/container-images/tcib/base/ansible-tests/ansible_sudoers
@@ -1,1 +1,0 @@
-ansible        ALL=(ALL)       NOPASSWD: ALL

--- a/container-images/tcib/base/os/horizontest/horizontest.yaml
+++ b/container-images/tcib/base/os/horizontest/horizontest.yaml
@@ -7,8 +7,7 @@ tcib_actions:
 - run: python3 -m pip install --upgrade pip 'setuptools<82'
 - run: echo "setuptools<82" > /tmp/horizon-build-constraints.txt
 - run: pip install {{ tcib_packages.pip_packages | join(' ') }}
-- run: cp /usr/share/tcib/container-images/tcib/base/os/horizontest/horizontest_sudoers /etc/sudoers.d/horizontest_sudoers
-- run: chmod 440 /etc/sudoers.d/horizontest_sudoers
+# No sudoers: horizontest does not need root.
 - run: mkdir -p /var/lib/horizontest/external_files
 - run: chown -R horizontest.horizontest /var/lib/horizontest
 - run: >-

--- a/container-images/tcib/base/os/horizontest/horizontest_sudoers
+++ b/container-images/tcib/base/os/horizontest/horizontest_sudoers
@@ -1,1 +1,0 @@
-horizontest        ALL=(ALL)       NOPASSWD: ALL

--- a/container-images/tcib/base/os/rally/rally.yaml
+++ b/container-images/tcib/base/os/rally/rally.yaml
@@ -3,8 +3,7 @@ tcib_envs:
 tcib_actions:
 - run: bash /usr/local/bin/uid_gid_manage {{ tcib_user }}
 - run: dnf -y install {{ tcib_packages['common'] | join(' ') }} && dnf clean all && rm -rf /var/cache/dnf
-- run: cp /usr/share/tcib/container-images/tcib/base/os/rally/rally_sudoers /etc/sudoers.d/rally_sudoers
-- run: chmod 440 /etc/sudoers.d/rally_sudoers
+# No sudoers: rally does not need root.
 - run: mkdir -p /var/lib/rally/external_files
 - run: mkdir -p /var/lib/kolla/config_files
 - run: chown -R rally.rally /var/lib/rally

--- a/container-images/tcib/base/os/rally/rally_sudoers
+++ b/container-images/tcib/base/os/rally/rally_sudoers
@@ -1,1 +1,0 @@
-rally        ALL=(ALL)       NOPASSWD: ALL

--- a/container-images/tcib/base/os/tempest/tempest_sudoers
+++ b/container-images/tcib/base/os/tempest/tempest_sudoers
@@ -1,1 +1,2 @@
-tempest        ALL=(ALL)       NOPASSWD: ALL
+# Limit root access to optional Tempest plugin installs.
+tempest ALL=(root) NOPASSWD: /usr/bin/dnf install -y *

--- a/container-images/tcib/base/tobiko/tobiko_sudoers
+++ b/container-images/tcib/base/tobiko/tobiko_sudoers
@@ -1,1 +1,3 @@
-tobiko        ALL=(ALL)       NOPASSWD: ALL
+# Tobiko sanity checks need limited host network inspection.
+tobiko ALL=(root) NOPASSWD: /bin/sh -c /sbin/ip\ --brief\ address\ list
+tobiko ALL=(root) NOPASSWD: /bin/sh -c /sbin/ip\ -o\ netns\ list

--- a/zuul.d/job.yaml
+++ b/zuul.d/job.yaml
@@ -9,6 +9,9 @@
       cifmw_set_openstack_containers_namespace: podified-master-centos9
       cifmw_update_containers_org: "podified-master-centos9"
       cifmw_build_containers_registry_namespace: podified-master-centos9
+      cifmw_build_containers_install_from_source: true
+      cifmw_build_containers_tcib_src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib"
+      cifmw_build_containers_config_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/tcib/container-images"
       cifmw_install_yamls_vars_patch_registry_url:
         DATAPLANE_REGISTRY_URL: quay.io/podified-master-centos9
 


### PR DESCRIPTION
Drop the unneeded broad sudoers entries from the ansible-tests, horizontest, rally, and tobiko images, restrict Tempest to package installation, and replace the kolla wildcard rule with explicit helper commands.

Keep the MariaDB bootstrap environment needed by kolla_security_reset so the tighter kolla allowlist does not break bootstrap.

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/537
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/4100
jira: [OSPRH-34490](https://redhat.atlassian.net/browse/OSPRH-34490)