### PR TITLE
Harden ansible  SSH defaults

### DIFF
--- a/tcib/client/utils.py
+++ b/tcib/client/utils.py
@@ -347,8 +347,7 @@ def run_ansible_playbook(playbook, inventory, workdir, playbook_dir=None,
 
     env = dict()
     env['ANSIBLE_SSH_ARGS'] = (
-        '-o UserKnownHostsFile={} '
-        '-o StrictHostKeyChecking=no '
+        '-o StrictHostKeyChecking=accept-new '
         '-o ControlMaster=auto '
         '-o ControlPersist=30m '
         '-o ServerAliveInterval=64 '
@@ -357,10 +356,9 @@ def run_ansible_playbook(playbook, inventory, workdir, playbook_dir=None,
         '-o TCPKeepAlive=yes '
         '-o VerifyHostKeyDNS=no '
         '-o ForwardX11=no '
-        '-o ForwardAgent=yes '
         '-o PreferredAuthentications=publickey '
         '-T'
-    ).format(os.devnull)
+    )
     env['ANSIBLE_DISPLAY_FAILED_STDERR'] = True
     env['ANSIBLE_FORKS'] = forks
     env['ANSIBLE_TIMEOUT'] = ansible_timeout
@@ -401,7 +399,6 @@ def run_ansible_playbook(playbook, inventory, workdir, playbook_dir=None,
         roles_path = os.path.join(_get_development_prefix(), 'roles')
         env['ANSIBLE_ROLES_PATH'] += ":{}".format(roles_path)
     env['ANSIBLE_RETRY_FILES_ENABLED'] = False
-    env['ANSIBLE_HOST_KEY_CHECKING'] = False
     env['ANSIBLE_TRANSPORT'] = connection
     env['ANSIBLE_CACHE_PLUGIN_TIMEOUT'] = 7200
 

--- a/tcib/tests/test_utils.py
+++ b/tcib/tests/test_utils.py
@@ -1,0 +1,98 @@
+import io
+import os
+import tempfile
+from unittest import mock
+
+from tcib.client import utils
+from tcib.tests import base
+
+
+class FakeRunnerConfig(object):
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.command = ['ansible-playbook', kwargs['playbook']]
+        self.prepare = mock.Mock()
+        self.__class__.instances.append(self)
+
+
+class FakeRunner(object):
+    def __init__(self, config):
+        self.config = config
+        self.stdout = io.StringIO('ok')
+        self.status = 'successful'
+        self.rc = 0
+
+    def run(self):
+        return self.status, self.rc
+
+
+class TestRunAnsiblePlaybook(base.TestCase):
+    def setUp(self):
+        super(TestRunAnsiblePlaybook, self).setUp()
+        FakeRunnerConfig.instances = []
+
+    @mock.patch.object(utils.ansible_runner, 'Runner', autospec=True)
+    @mock.patch.object(
+        utils.ansible_runner.runner_config, 'RunnerConfig', autospec=True
+    )
+    def test_run_ansible_playbook_uses_safe_ssh_defaults(
+        self, mock_runner_config, mock_runner
+    ):
+        mock_runner_config.side_effect = FakeRunnerConfig
+        mock_runner.side_effect = FakeRunner
+
+        with tempfile.TemporaryDirectory() as workdir:
+            playbook = os.path.join(workdir, 'playbook.yaml')
+            with open(playbook, 'w') as f:
+                f.write('---\n- hosts: localhost\n  tasks: []\n')
+
+            utils.run_ansible_playbook(
+                playbook=playbook,
+                inventory='localhost,',
+                workdir=workdir,
+                playbook_dir=workdir,
+                connection='local',
+                reproduce_command=False,
+            )
+
+        envvars = FakeRunnerConfig.instances[0].kwargs['envvars']
+        ssh_args = envvars['ANSIBLE_SSH_ARGS']
+
+        self.assertIn('-o StrictHostKeyChecking=accept-new', ssh_args)
+        self.assertNotIn('UserKnownHostsFile', ssh_args)
+        self.assertNotIn('ForwardAgent=yes', ssh_args)
+        self.assertNotIn('ANSIBLE_HOST_KEY_CHECKING', envvars)
+
+    @mock.patch.object(utils.ansible_runner, 'Runner', autospec=True)
+    @mock.patch.object(
+        utils.ansible_runner.runner_config, 'RunnerConfig', autospec=True
+    )
+    def test_run_ansible_playbook_allows_env_overrides(
+        self, mock_runner_config, mock_runner
+    ):
+        mock_runner_config.side_effect = FakeRunnerConfig
+        mock_runner.side_effect = FakeRunner
+
+        with tempfile.TemporaryDirectory() as workdir:
+            playbook = os.path.join(workdir, 'playbook.yaml')
+            with open(playbook, 'w') as f:
+                f.write('---\n- hosts: localhost\n  tasks: []\n')
+
+            utils.run_ansible_playbook(
+                playbook=playbook,
+                inventory='localhost,',
+                workdir=workdir,
+                playbook_dir=workdir,
+                connection='local',
+                reproduce_command=False,
+                extra_env_variables={
+                    'ANSIBLE_SSH_ARGS': '-o ForwardAgent=yes',
+                    'ANSIBLE_HOST_KEY_CHECKING': 'False',
+                },
+            )
+
+        envvars = FakeRunnerConfig.instances[0].kwargs['envvars']
+        self.assertEqual(envvars['ANSIBLE_SSH_ARGS'], '-o ForwardAgent=yes')
+        self.assertEqual(envvars['ANSIBLE_HOST_KEY_CHECKING'], 'False')


### PR DESCRIPTION
Use safer SSH defaults for ansible-runner so remote playbook runs do not disable host verification or expose forwarded SSH agents by default.

jira: [OSPRH-34804](https://redhat.atlassian.net/browse/OSPRH-34804)